### PR TITLE
feat(render,shell): add disk/network rate formatters and enhance QML cockpit scene

### DIFF
--- a/src/render/native/include/aura_render.h
+++ b/src/render/native/include/aura_render.h
@@ -181,6 +181,18 @@ AURA_RENDER_API void aura_format_stream_status(
     size_t out_status_size
 );
 
+AURA_RENDER_API void aura_format_disk_rate(
+    double bytes_per_second,
+    char* out_rate,
+    size_t out_rate_size
+);
+
+AURA_RENDER_API void aura_format_network_rate(
+    double bytes_per_second,
+    char* out_rate,
+    size_t out_rate_size
+);
+
 AURA_RENDER_API AuraQtRenderBackendCaps aura_qt_hooks_backend_caps(void);
 
 AURA_RENDER_API AuraQtRenderHooks* aura_qt_hooks_create(

--- a/src/render/native/include/render_native/formatting.hpp
+++ b/src/render/native/include/render_native/formatting.hpp
@@ -24,4 +24,7 @@ std::string format_process_row(
     int max_chars = kDefaultProcessNameMaxChars
 );
 
+std::string format_disk_rate(double bytes_per_second);
+std::string format_network_rate(double bytes_per_second);
+
 }  // namespace aura::render_native

--- a/src/render/native/src/c_api.cpp
+++ b/src/render/native/src/c_api.cpp
@@ -476,6 +476,34 @@ void aura_format_stream_status(
     }
 }
 
+void aura_format_disk_rate(
+    double bytes_per_second,
+    char* out_rate,
+    size_t out_rate_size
+) {
+    const bool ok = call_void_with_error("aura_format_disk_rate", [&]() {
+        const std::string value = aura::render_native::format_disk_rate(bytes_per_second);
+        write_c_string(value, out_rate, out_rate_size);
+    });
+    if (!ok) {
+        write_c_chars("Disk 0.0 KB/s", out_rate, out_rate_size);
+    }
+}
+
+void aura_format_network_rate(
+    double bytes_per_second,
+    char* out_rate,
+    size_t out_rate_size
+) {
+    const bool ok = call_void_with_error("aura_format_network_rate", [&]() {
+        const std::string value = aura::render_native::format_network_rate(bytes_per_second);
+        write_c_string(value, out_rate, out_rate_size);
+    });
+    if (!ok) {
+        write_c_chars("Net 0.0 KB/s", out_rate, out_rate_size);
+    }
+}
+
 AuraQtRenderBackendCaps aura_qt_hooks_backend_caps(void) {
     const AuraQtRenderBackendCaps fallback_caps{0, 1, kDefaultTargetFps};
     return call_with_fallback<AuraQtRenderBackendCaps>(

--- a/src/render/native/src/formatting.cpp
+++ b/src/render/native/src/formatting.cpp
@@ -84,4 +84,35 @@ std::string format_process_row(
     return out.str();
 }
 
+namespace {
+
+std::string format_bytes_per_second(const char* prefix, double bytes_per_second) {
+    const double safe_value = sanitize_non_negative(bytes_per_second);
+    std::ostringstream out;
+    out << prefix << " ";
+
+    constexpr double kKB = 1024.0;
+    constexpr double kMB = 1024.0 * 1024.0;
+    constexpr double kGB = 1024.0 * 1024.0 * 1024.0;
+
+    if (safe_value >= kGB) {
+        out << std::fixed << std::setprecision(2) << (safe_value / kGB) << " GB/s";
+    } else if (safe_value >= kMB) {
+        out << std::fixed << std::setprecision(1) << (safe_value / kMB) << " MB/s";
+    } else {
+        out << std::fixed << std::setprecision(1) << (safe_value / kKB) << " KB/s";
+    }
+    return out.str();
+}
+
+}  // namespace
+
+std::string format_disk_rate(double bytes_per_second) {
+    return format_bytes_per_second("Disk", bytes_per_second);
+}
+
+std::string format_network_rate(double bytes_per_second) {
+    return format_bytes_per_second("Net", bytes_per_second);
+}
+
 }  // namespace aura::render_native

--- a/src/shell/native/qml/CockpitScene.qml
+++ b/src/shell/native/qml/CockpitScene.qml
@@ -4,6 +4,7 @@ Rectangle {
     id: root
     color: "#0d2034"
     radius: 8
+    clip: true
 
     property real accentIntensity: 0.0
     property real cpuPercent: 0.0
@@ -14,40 +15,166 @@ Rectangle {
         NumberAnimation { duration: 180; easing.type: Easing.OutCubic }
     }
 
-    Rectangle {
-        id: gaugeRing
-        width: Math.min(parent.width, parent.height) * 0.55
-        height: width
-        radius: width / 2
-        anchors.centerIn: parent
-        color: "transparent"
-        border.width: 8
-        border.color: Qt.rgba(0.30 + (root.accentIntensity * 0.45), 0.58, 0.80, 0.95)
-    }
-
     Text {
-        text: "Native Cockpit"
+        id: titleLabel
+        text: "AURA COCKPIT"
         anchors.horizontalCenter: parent.horizontalCenter
         anchors.top: parent.top
-        anchors.topMargin: 18
+        anchors.topMargin: 14
         color: "#d7ebff"
-        font.pixelSize: 20
+        font.pixelSize: 18
+        font.weight: Font.DemiBold
+        font.letterSpacing: 2
+    }
+
+    Row {
+        id: gaugeRow
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.top: titleLabel.bottom
+        anchors.topMargin: 20
+        spacing: 40
+
+        Item {
+            id: cpuGauge
+            width: Math.min(root.width * 0.28, 160)
+            height: width
+
+            Rectangle {
+                id: cpuRing
+                anchors.centerIn: parent
+                width: parent.width
+                height: width
+                radius: width / 2
+                color: "transparent"
+                border.width: 6 + (root.accentIntensity * 4)
+                border.color: Qt.rgba(
+                    0.25 + (root.cpuPercent / 100.0) * 0.55,
+                    0.55 - (root.cpuPercent / 100.0) * 0.30,
+                    0.80 - (root.cpuPercent / 100.0) * 0.40,
+                    0.90
+                )
+
+                Behavior on border.width {
+                    NumberAnimation { duration: 200; easing.type: Easing.OutQuad }
+                }
+                Behavior on border.color {
+                    ColorAnimation { duration: 300 }
+                }
+            }
+
+            Column {
+                anchors.centerIn: parent
+                spacing: 2
+
+                Text {
+                    text: "CPU"
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    color: "#9fc8e8"
+                    font.pixelSize: 11
+                    font.weight: Font.Medium
+                    font.letterSpacing: 1
+                }
+
+                Text {
+                    text: root.cpuPercent.toFixed(1) + "%"
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    color: "#e0f0ff"
+                    font.pixelSize: 22
+                    font.weight: Font.Bold
+                }
+            }
+        }
+
+        Item {
+            id: memGauge
+            width: Math.min(root.width * 0.28, 160)
+            height: width
+
+            Rectangle {
+                id: memRing
+                anchors.centerIn: parent
+                width: parent.width
+                height: width
+                radius: width / 2
+                color: "transparent"
+                border.width: 6 + (root.accentIntensity * 4)
+                border.color: Qt.rgba(
+                    0.30 + (root.memoryPercent / 100.0) * 0.45,
+                    0.45,
+                    0.70 + (root.memoryPercent / 100.0) * 0.15,
+                    0.90
+                )
+
+                Behavior on border.width {
+                    NumberAnimation { duration: 200; easing.type: Easing.OutQuad }
+                }
+                Behavior on border.color {
+                    ColorAnimation { duration: 300 }
+                }
+            }
+
+            Column {
+                anchors.centerIn: parent
+                spacing: 2
+
+                Text {
+                    text: "MEM"
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    color: "#9fc8e8"
+                    font.pixelSize: 11
+                    font.weight: Font.Medium
+                    font.letterSpacing: 1
+                }
+
+                Text {
+                    text: root.memoryPercent.toFixed(1) + "%"
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    color: "#e0f0ff"
+                    font.pixelSize: 22
+                    font.weight: Font.Bold
+                }
+            }
+        }
+    }
+
+    Rectangle {
+        id: divider
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.top: gaugeRow.bottom
+        anchors.topMargin: 16
+        width: parent.width * 0.75
+        height: 1
+        color: Qt.rgba(0.30, 0.55, 0.78, 0.30 + root.accentIntensity * 0.20)
     }
 
     Text {
-        text: "CPU " + cpuPercent.toFixed(1) + "%  |  Memory " + memoryPercent.toFixed(1) + "%"
+        id: statusLabel
+        text: root.statusText
         anchors.horizontalCenter: parent.horizontalCenter
-        anchors.verticalCenter: parent.verticalCenter
-        color: "#c2dcf2"
-        font.pixelSize: 15
-    }
-
-    Text {
-        text: statusText
-        anchors.horizontalCenter: parent.horizontalCenter
-        anchors.bottom: parent.bottom
-        anchors.bottomMargin: 18
+        anchors.top: divider.bottom
+        anchors.topMargin: 12
         color: "#9fc8e8"
-        font.pixelSize: 13
+        font.pixelSize: 12
+        elide: Text.ElideRight
+        width: parent.width * 0.85
+        horizontalAlignment: Text.AlignHCenter
+    }
+
+    Rectangle {
+        id: accentGlow
+        anchors.fill: parent
+        color: "transparent"
+        border.width: 2
+        border.color: Qt.rgba(
+            0.20 + root.accentIntensity * 0.50,
+            0.45 + root.accentIntensity * 0.25,
+            0.75,
+            0.15 + root.accentIntensity * 0.35
+        )
+        radius: root.radius
+
+        Behavior on border.color {
+            ColorAnimation { duration: 250 }
+        }
     }
 }

--- a/tests/test_render/render_native_tests.cpp
+++ b/tests/test_render/render_native_tests.cpp
@@ -199,6 +199,50 @@ void test_formatting_and_status() {
     assert(std::strcmp(status, "Streaming telemetry | DVR unavailable: disk full") == 0);
 }
 
+void test_format_disk_rate() {
+    char buf[64] = {};
+
+    // Sub-MB: should format as KB/s
+    aura_format_disk_rate(512.0 * 1024.0, buf, sizeof(buf));
+    assert(std::strcmp(buf, "Disk 512.0 KB/s") == 0);
+
+    // Exactly 1 MB/s
+    aura_format_disk_rate(1024.0 * 1024.0, buf, sizeof(buf));
+    assert(std::strcmp(buf, "Disk 1.0 MB/s") == 0);
+
+    // Large value: GB/s
+    aura_format_disk_rate(2.5 * 1024.0 * 1024.0 * 1024.0, buf, sizeof(buf));
+    assert(std::strcmp(buf, "Disk 2.50 GB/s") == 0);
+
+    // Zero
+    aura_format_disk_rate(0.0, buf, sizeof(buf));
+    assert(std::strcmp(buf, "Disk 0.0 KB/s") == 0);
+
+    // Negative clamped to zero
+    aura_format_disk_rate(-100.0, buf, sizeof(buf));
+    assert(std::strcmp(buf, "Disk 0.0 KB/s") == 0);
+}
+
+void test_format_network_rate() {
+    char buf[64] = {};
+
+    // Sub-MB: should format as KB/s
+    aura_format_network_rate(256.0 * 1024.0, buf, sizeof(buf));
+    assert(std::strcmp(buf, "Net 256.0 KB/s") == 0);
+
+    // MB/s range
+    aura_format_network_rate(10.0 * 1024.0 * 1024.0, buf, sizeof(buf));
+    assert(std::strcmp(buf, "Net 10.0 MB/s") == 0);
+
+    // GB/s range
+    aura_format_network_rate(1.0 * 1024.0 * 1024.0 * 1024.0, buf, sizeof(buf));
+    assert(std::strcmp(buf, "Net 1.00 GB/s") == 0);
+
+    // Small value
+    aura_format_network_rate(100.0, buf, sizeof(buf));
+    assert(std::strcmp(buf, "Net 0.1 KB/s") == 0);
+}
+
 void test_widgets_backend() {
     const char* backend = aura_widget_backend_name();
     assert(backend != nullptr);
@@ -454,6 +498,8 @@ int main() {
     test_theme();
     test_c_api_error_surface_and_fallbacks();
     test_formatting_and_status();
+    test_format_disk_rate();
+    test_format_network_rate();
     test_widgets_backend();
     test_qt_hooks_caps_and_lifecycle();
     test_qt_hooks_callback_order_and_ranges();


### PR DESCRIPTION
## Summary
- Add aura_format_disk_rate and aura_format_network_rate C ABI functions to RENDER module for human-readable byte rate formatting (KB/s, MB/s, GB/s) with negative/NaN sanitization
- Enhance CockpitScene.qml with dual radial gauges (CPU + Memory), accent-reactive border glow, animated transitions, and status text display
- Add comprehensive tests for both new formatting functions covering zero, negative, KB/s, MB/s, and GB/s ranges

## Test plan
- [x] Render native tests pass (1/1 passed)
- [x] Shell native tests pass (3/3 passed)
- [ ] Reviewer verifies no cross-module boundary violations
- [ ] Reviewer verifies C ABI contract (no exceptions across boundary, fallback returns)

Generated with [Claude Code](https://claude.com/claude-code)