### PR TITLE
chore: add root CMakeLists.txt superbuild and update architecture docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,9 @@ compile_commands.json
 # ── Build output directories ──
 build/
 src/build/
+src/shell/native/build/
 out/
+dist/
 
 # ── Visual Studio ──
 .vs/

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,18 +1,18 @@
-# ARCHITECTURE.md - Module Ownership and Parallel Development
+# ARCHITECTURE.md -- Module Ownership and Parallel Development
 
 > 4 engineers. Zero file overlap. Zero lock loops. Each owns a directory.
 
-## Part 1 - Current Product Modules
+## Part 1 -- Current Product Modules
 
-| Module | Purpose | Owned Paths |
-|---|---|---|
-| Overhead | Process, prompts, shared docs | All root `*.md` files |
-| Telemetry | Data collection and sensor pipeline | `src/telemetry/**` |
-| Render | Visual primitives and effects | `src/render/**` |
-| Shell | Window, panels, interaction | `src/shell/**` |
-| Platform | Runtime, store, packaging surface | `src/runtime/**` |
+| Module | Purpose | Owned Paths | Status |
+|---|---|---|---|
+| Overhead | Process, prompts, shared docs | All root `*.md` files | Active |
+| Telemetry (SENSOR) | Data collection and sensor pipeline | `src/telemetry/**` | C ABI DLL implemented |
+| Render (RENDER) | Visual primitives and effects | `src/render/**` | C ABI DLL implemented |
+| Shell (SHELL) | Window, panels, interaction | `src/shell/**` | Static lib + Qt6 app implemented |
+| Platform (PLATFORM) | Runtime, store, packaging surface | `src/runtime/**` | C ABI DLL + CLI implemented |
 
-## Part 2 - 2-3 Year Work Balance
+## Part 2 -- 2-3 Year Work Balance
 
 | Engineer | Module | 2-3 Year Work Focus | Workload |
 |---|---|---|---|
@@ -23,7 +23,7 @@
 
 Overhead remains shared and lean.
 
-## Part 3 - Final Ownership Split (Strict)
+## Part 3 -- Final Ownership Split (Strict)
 
 1. **SENSOR**
 - Code: `src/telemetry/**`
@@ -41,12 +41,49 @@ Overhead remains shared and lean.
 - Code: `src/runtime/**`
 - Tests: `tests/test_platform/**`
 
-## C++ Rewrite Baseline
+## Build System -- Root Superbuild
 
-- Product direction is now native C++.
-- Platform runtime has been cut over to native C++ (`src/runtime/native/**`).
-- Platform test suite is native C++ (`tests/test_platform/native/**`).
-- Build standard: CMake + Visual Studio 2022 generator on Windows (`-A x64`).
+A root `CMakeLists.txt` provides a single-command build for all modules:
+
+```bash
+# Configure (Qt6 optional -- omit Qt6_DIR to skip shell app)
+cmake -S . -B build -G "Visual Studio 17 2022" -A x64 \
+      -DQt6_DIR="C:/Qt/6.10.2/msvc2022_64/lib/cmake/Qt6"
+
+# Build everything
+cmake --build build --config Release
+
+# Run all tests
+ctest --test-dir build -C Release --output-on-failure
+```
+
+### Superbuild structure
+
+The root CMakeLists.txt adds each native module as a subdirectory:
+
+```
+CMakeLists.txt (root superbuild)
+  |-- src/runtime/native/    -> aura_platform (DLL) + aura (CLI)
+  |-- src/telemetry/native/  -> aura_telemetry_native (DLL)
+  |-- src/render/native/     -> aura_render_native (DLL)
+  |-- src/shell/native/      -> aura_shell_core (static) + aura_shell (Qt6 app)
+  |-- tests/                 -> test executables linked against the above
+```
+
+All build artifacts land in `build/bin/` so DLLs are co-located with executables
+and tests can find them without manual copy steps.
+
+### Qt6 handling
+
+Qt6 is optional. When not found:
+- SHELL app target (`aura_shell`) is not built; core library and tests still build.
+- RENDER Qt widget hooks are disabled; pure-math and C ABI layer still builds.
+- PLATFORM and SENSOR have no Qt dependency and always build.
+
+### Individual module builds
+
+Each module retains its own standalone CMakeLists.txt for isolated development.
+See `CLAUDE.md` for per-module build commands.
 
 ## Target Directory Layout
 
@@ -54,31 +91,64 @@ Overhead remains shared and lean.
 src/
 |-- telemetry/
 |   `-- native/
+|       |-- include/         # C ABI header: aura_telemetry.h
+|       `-- src/             # telemetry_engine.cpp, aura_telemetry_native.cpp
 |-- render/
 |   `-- native/
+|       |-- include/         # C ABI header: aura_render.h
+|       `-- src/             # c_api.cpp, math.cpp, theme.cpp, widgets.cpp, ...
 |-- shell/
 |   `-- native/
+|       |-- include/         # bridge headers
+|       |-- src/             # main.cpp, cockpit_controller.cpp, dock_model.cpp, ...
+|       |-- qml/             # CockpitScene.qml
+|       `-- tests/           # inline shell tests
 `-- runtime/
     `-- native/
-        |-- include/
-        `-- src/
+        |-- include/         # C ABI header: aura_platform.h
+        `-- src/             # c_api.cpp, config_win.cpp, store_sqlite.cpp, ...
 
 tests/
-|-- test_telemetry/
-|-- test_render/
-|-- test_shell/
-`-- test_platform/
-    `-- native/
+|-- test_telemetry/native/   # test_telemetry_native.cpp
+|-- test_render/             # render_native_tests.cpp
+`-- test_platform/native/    # test_platform_native.cpp
 ```
+
+## Cross-Module Dependencies
+
+```
+SHELL --> SENSOR   (reads telemetry snapshots via C ABI)
+SHELL --> RENDER   (uses visual primitives via C ABI)
+SHELL --> PLATFORM (reads config, calls runtime APIs)
+
+SENSOR --> (system APIs only, no module deps)
+RENDER --> (standalone, optional Qt6 for widget hooks)
+PLATFORM --> (standalone, Windows APIs + SQLite)
+```
+
+The SHELL module includes headers from all three other modules via relative
+paths in its `target_include_directories`. No circular dependencies exist.
 
 ## Interface Contracts
 
-Cross-module type contracts are defined as C++ headers within each module's `native/include/` directory. Coordination happens through `groupchat.md`.
+Cross-module type contracts are defined as C headers within each module's
+`native/include/` directory. All boundaries use the C ABI:
 
-- SENSOR -> SHELL: telemetry snapshots via C ABI (`telemetry_engine.h`)
-- RENDER -> SHELL: visual primitives via C ABI (`aura_render.h`)
-- SENSOR -> PLATFORM: persistent telemetry stream to DVR/store
-- SHELL -> PLATFORM: runtime config, window state, platform calls
+- **SENSOR C ABI** (`aura_telemetry.h`): Opaque engine handle, snapshot structs,
+  top-k process sampling. Consumers: SHELL (telemetry_bridge.cpp).
+- **RENDER C ABI** (`aura_render.h`): Style tokens, math primitives, widget
+  models (RadialGauge, SparkLine, Timeline, GlassPanel). Consumers: SHELL
+  (render_bridge.cpp).
+- **PLATFORM C ABI** (`aura_platform.h`): Runtime config resolution
+  (CLI>env>TOML>auto), atomic file store with crash recovery, DVR with LTTB
+  downsampling. Consumers: SHELL (timeline_bridge.cpp), CLI (runtime_cli.cpp).
+
+### C ABI rules
+
+- Opaque handles (pointers to forward-declared structs)
+- No C++ exceptions across boundary; thread-local error reporting
+- Fallback return values on error
+- `extern "C"` linkage on all exported symbols
 
 ## Coordination Rules (No Lock Theater)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,131 @@
+# ===========================================================================
+# Aura System Monitor -- Root Superbuild
+# ===========================================================================
+#
+# Single-command build for all 4 native modules:
+#
+#   cmake -S . -B build -G "Visual Studio 17 2022" -A x64
+#   cmake --build build --config Release
+#   ctest --test-dir build -C Release --output-on-failure
+#
+# Qt6 is optional. If not found, the SHELL app target is skipped and the
+# RENDER module builds without Qt widget hooks. Everything else builds fine.
+#
+# To point CMake at a Qt6 installation:
+#   cmake -S . -B build -G "Visual Studio 17 2022" -A x64 \
+#         -DQt6_DIR="C:/Qt/6.10.2/msvc2022_64/lib/cmake/Qt6"
+# ===========================================================================
+
+cmake_minimum_required(VERSION 3.23)
+
+project(aura
+    VERSION 0.1.0
+    DESCRIPTION "Aura -- native Windows system monitor"
+    LANGUAGES CXX
+)
+
+# ---- Global defaults ----------------------------------------------------
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+# Place all build artifacts in a predictable location so DLLs are next to
+# executables and tests can find them without post-build copy steps.
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib")
+
+# ---- Options ------------------------------------------------------------
+
+option(AURA_BUILD_TESTS "Build test executables for all modules" ON)
+
+# ---- Module: PLATFORM (runtime, config, DVR, store) ---------------------
+
+add_subdirectory(src/runtime/native)
+
+# ---- Module: SENSOR (telemetry collection) ------------------------------
+
+add_subdirectory(src/telemetry/native)
+
+# ---- Module: RENDER (visual primitives, widgets, compositor) ------------
+
+add_subdirectory(src/render/native)
+
+# ---- Module: SHELL (Qt6 frameless window, docking, QML cockpit) --------
+# Shell is added last because it depends on headers from the other three
+# modules. The shell CMakeLists handles Qt6 discovery internally and
+# degrades gracefully when Qt6 is not available.
+
+add_subdirectory(src/shell/native)
+
+# ---- Tests --------------------------------------------------------------
+
+if(AURA_BUILD_TESTS)
+    enable_testing()
+
+    # -- Platform tests ---------------------------------------------------
+    add_executable(platform_native_tests
+        tests/test_platform/native/test_platform_native.cpp
+    )
+    target_include_directories(platform_native_tests PRIVATE
+        src/runtime/native/include
+    )
+    target_link_libraries(platform_native_tests PRIVATE aura_platform)
+    target_compile_features(platform_native_tests PRIVATE cxx_std_20)
+    if(MSVC)
+        target_compile_options(platform_native_tests PRIVATE /W4 /EHsc)
+    endif()
+    add_test(NAME platform_native_tests COMMAND platform_native_tests)
+
+    # CLI malformed-arg rejection tests (the 'aura' CLI is built by the
+    # platform module).
+    add_test(
+        NAME platform_cli_rejects_malformed_retention
+        COMMAND $<TARGET_FILE:aura> --retention-seconds 10foo --no-persist
+    )
+    set_tests_properties(platform_cli_rejects_malformed_retention
+        PROPERTIES WILL_FAIL TRUE
+    )
+    add_test(
+        NAME platform_cli_rejects_malformed_interval
+        COMMAND $<TARGET_FILE:aura> --watch --count 1 --interval 1x --no-persist
+    )
+    set_tests_properties(platform_cli_rejects_malformed_interval
+        PROPERTIES WILL_FAIL TRUE
+    )
+
+    # -- Telemetry tests --------------------------------------------------
+    add_executable(aura_telemetry_native_tests
+        tests/test_telemetry/native/test_telemetry_native.cpp
+    )
+    target_include_directories(aura_telemetry_native_tests PRIVATE
+        src/telemetry/native/include
+    )
+    target_link_libraries(aura_telemetry_native_tests PRIVATE aura_telemetry_native)
+    add_test(NAME aura_telemetry_native_tests COMMAND aura_telemetry_native_tests)
+
+    # -- Render tests -----------------------------------------------------
+    add_executable(render_native_tests
+        tests/test_render/render_native_tests.cpp
+    )
+    target_include_directories(render_native_tests PRIVATE
+        src/render/native/include
+    )
+    target_link_libraries(render_native_tests PRIVATE aura_render_native)
+    add_test(NAME render_native_tests COMMAND render_native_tests)
+
+    # -- Shell tests (already defined inline by src/shell/native) ---------
+    # The shell CMakeLists.txt defines its own test targets:
+    #   aura_shell_dock_model_tests
+    #   aura_shell_cockpit_controller_tests
+    #   aura_shell_timeline_bridge_tests
+endif()
+
+# ---- Install ------------------------------------------------------------
+
+install(TARGETS aura aura_platform aura_telemetry_native aura_render_native
+    RUNTIME DESTINATION bin
+    LIBRARY DESTINATION bin
+    ARCHIVE DESTINATION lib
+)


### PR DESCRIPTION
## Summary
- Add root `CMakeLists.txt` superbuild that builds all 4 native modules (PLATFORM, SENSOR, RENDER, SHELL) with a single `cmake -S . -B build` command
- Qt6 is optional: when absent, the shell app is skipped but all libraries, CLI, and tests build successfully (8/8 tests pass)
- All build artifacts land in `build/bin/` so DLLs are co-located with test executables (no post-build copy steps needed)
- Update `ARCHITECTURE.md` with superbuild documentation, current module implementation status, cross-module dependency graph, and C ABI interface contract details
- Update `.gitignore` to cover `src/shell/native/build/` and `dist/`

## Test plan
- [x] `cmake -S . -B build -G "Visual Studio 17 2022" -A x64` configures successfully (with Qt6 warning, no errors)
- [x] `cmake --build build --config Release` compiles all targets
- [x] `ctest --test-dir build -C Release --output-on-failure` passes 8/8 tests
- [x] No files modified outside architect-owned paths (root CMakeLists.txt, .gitignore, ARCHITECTURE.md)

Generated with [Claude Code](https://claude.com/claude-code)