### PR TITLE
feat(sensor,platform): add per-core CPU, GPU stub, and disk BPS fields

### DIFF
--- a/src/runtime/native/include/aura_platform.h
+++ b/src/runtime/native/include/aura_platform.h
@@ -20,6 +20,8 @@ typedef struct aura_snapshot_t {
     double timestamp;
     double cpu_percent;
     double memory_percent;
+    double disk_read_bps;
+    double disk_write_bps;
 } aura_snapshot_t;
 
 enum aura_db_source_t {

--- a/src/runtime/native/src/c_api.cpp
+++ b/src/runtime/native/src/c_api.cpp
@@ -53,6 +53,8 @@ Snapshot ToInternalSnapshot(const aura_snapshot_t& raw) {
     out.timestamp = raw.timestamp;
     out.cpu_percent = raw.cpu_percent;
     out.memory_percent = raw.memory_percent;
+    out.disk_read_bps = raw.disk_read_bps;
+    out.disk_write_bps = raw.disk_write_bps;
     return out;
 }
 
@@ -61,6 +63,8 @@ aura_snapshot_t ToAbiSnapshot(const Snapshot& raw) {
     out.timestamp = raw.timestamp;
     out.cpu_percent = raw.cpu_percent;
     out.memory_percent = raw.memory_percent;
+    out.disk_read_bps = raw.disk_read_bps;
+    out.disk_write_bps = raw.disk_write_bps;
     return out;
 }
 

--- a/src/runtime/native/src/platform_internal.hpp
+++ b/src/runtime/native/src/platform_internal.hpp
@@ -15,6 +15,8 @@ struct Snapshot {
     double timestamp = 0.0;
     double cpu_percent = 0.0;
     double memory_percent = 0.0;
+    double disk_read_bps = 0.0;
+    double disk_write_bps = 0.0;
 };
 
 enum class DbSource {

--- a/src/telemetry/native/include/telemetry_abi.h
+++ b/src/telemetry/native/include/telemetry_abi.h
@@ -46,6 +46,18 @@ struct aura_thermal_reading {
     uint8_t has_critical;
 };
 
+struct aura_per_core_cpu {
+    double* percents;
+    uint32_t count;
+};
+
+struct aura_gpu_utilization {
+    double gpu_percent;
+    double vram_percent;
+    uint64_t vram_used_bytes;
+    uint64_t vram_total_bytes;
+};
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -81,6 +93,20 @@ AURA_EXPORT int aura_collect_thermal_readings(
     aura_thermal_reading* readings,
     uint32_t max_samples,
     uint32_t* out_count,
+    char* error_buffer,
+    size_t error_buffer_len
+);
+
+AURA_EXPORT int aura_collect_per_core_cpu(
+    double* out_percents,
+    uint32_t max_cores,
+    uint32_t* out_core_count,
+    char* error_buffer,
+    size_t error_buffer_len
+);
+
+AURA_EXPORT int aura_collect_gpu_utilization(
+    aura_gpu_utilization* out_gpu,
     char* error_buffer,
     size_t error_buffer_len
 );


### PR DESCRIPTION
## Summary

- **SENSOR**: Add `aura_collect_per_core_cpu` C ABI using NtQuerySystemInformation for per-logical-processor CPU utilization, and `aura_collect_gpu_utilization` stub (returns AURA_STATUS_UNAVAILABLE) to establish the GPU ABI surface
- **SENSOR**: Add `PerCoreCpuSnapshot`, `GpuSnapshot` structs and `CollectPerCoreCpu`, `CollectGpuSnapshot` methods on TelemetryEngine with graceful degradation
- **PLATFORM**: Extend `aura_snapshot_t` with `disk_read_bps` and `disk_write_bps` fields, update CSV serialization to 5-field format with backward compatibility for legacy 3-field lines

## Test plan

- [x] 6 new telemetry tests: per-core CPU success/unavailable/null-collector, GPU unavailable/success/null-collector
- [x] 3 new platform tests: disk fields in-memory, disk fields file reopen, legacy 3-field backward compat
- [x] All existing telemetry tests pass (19 + 6 = 25 total)
- [x] All existing platform tests pass (3 + 3 = 6 total)

🤖 Generated with [Claude Code](https://claude.com/claude-code)