### PR TITLE
feat(shell,render): premium UI overhaul

### DIFF
--- a/src/render/native/include/render_native/theme.hpp
+++ b/src/render/native/include/render_native/theme.hpp
@@ -10,8 +10,58 @@ struct RgbColor {
     int blue{0};
 };
 
+// Named color palette for the Aura visual identity.
+struct AuraPalette {
+    // Background depths (darker = further back)
+    static constexpr const char* kWindowBg      = "#060b14";
+    static constexpr const char* kPanelBg       = "#0a1221";
+    static constexpr const char* kSurfaceBg     = "#0f1a2e";
+    static constexpr const char* kElevatedBg    = "#162238";
+
+    // Borders
+    static constexpr const char* kBorderSubtle  = "#1e3350";
+    static constexpr const char* kBorderActive  = "#2a4a6e";
+    static constexpr const char* kBorderAccent  = "#3b82f6";
+
+    // Text hierarchy
+    static constexpr const char* kTextPrimary   = "#e0ecf7";
+    static constexpr const char* kTextSecondary = "#8badc4";
+    static constexpr const char* kTextMuted     = "#4d6d87";
+    static constexpr const char* kTextDisabled  = "#2e4a63";
+
+    // Accent colors
+    static constexpr const char* kAccentBlue    = "#3b82f6";
+    static constexpr const char* kAccentCyan    = "#06b6d4";
+    static constexpr const char* kAccentAmber   = "#f59e0b";
+    static constexpr const char* kAccentRed     = "#ef4444";
+    static constexpr const char* kAccentGreen   = "#22c55e";
+
+    // Gauge colors
+    static constexpr const char* kGaugeTrack    = "#1a2940";
+    static constexpr const char* kGaugeLow      = "#3b82f6";
+    static constexpr const char* kGaugeMid      = "#06b6d4";
+    static constexpr const char* kGaugeHigh     = "#f59e0b";
+    static constexpr const char* kGaugeCritical = "#ef4444";
+};
+
+// Existing API — unchanged.
 RgbColor parse_hex_color(const std::string& value);
 std::string blend_hex_color(const std::string& start, const std::string& end, double ratio);
 int quantize_accent_intensity(double accent_intensity);
+
+// Returns an interpolated color based on a 0-100 percent value.
+// Segments:
+//   0-40  : blue (#3b82f6)
+//   40-70 : blue  -> cyan  (#3b82f6 -> #06b6d4)
+//   70-85 : cyan  -> amber (#06b6d4 -> #f59e0b)
+//   85-100: amber -> red   (#f59e0b -> #ef4444)
+RgbColor interpolate_gauge_color(double percent);
+std::string interpolate_gauge_color_hex(double percent);
+
+// Accessibility helpers.
+// relative_luminance returns the WCAG 2.x relative luminance in [0, 1].
+// contrast_ratio returns the WCAG 2.x contrast ratio in [1, 21].
+double relative_luminance(const RgbColor& color);
+double contrast_ratio(const RgbColor& foreground, const RgbColor& background);
 
 }  // namespace aura::render_native

--- a/src/render/native/include/render_native/widgets_models.hpp
+++ b/src/render/native/include/render_native/widgets_models.hpp
@@ -4,6 +4,8 @@
 #include <string>
 #include <vector>
 
+#include "render_native/theme.hpp"
+
 namespace aura::render_native {
 
 struct RadialGaugeConfig {
@@ -56,10 +58,28 @@ struct TimelinePoint {
 class RadialGaugeModel {
   public:
     explicit RadialGaugeModel(RadialGaugeConfig config = {});
+
+    // Existing API — unchanged.
     [[nodiscard]] double value() const;
     [[nodiscard]] double accent_intensity() const;
     void set_value(double value);
     void set_accent_intensity(double accent_intensity);
+
+    // Computed properties for rendering.
+
+    // Returns the sweep angle in degrees for the current value.
+    // For the default sweep_degrees of 270 and value of 50 this returns 135.0.
+    [[nodiscard]] double value_sweep_degrees() const;
+
+    // Returns the gauge color for the current value using interpolate_gauge_color.
+    [[nodiscard]] RgbColor value_color() const;
+
+    // Returns the arc start angle in radians for Canvas arc drawing.
+    // Follows the convention that 0 rad = 3-o'clock; angles increase clockwise.
+    [[nodiscard]] double arc_start_radians() const;
+
+    // Returns the arc end angle in radians that corresponds to the current value.
+    [[nodiscard]] double arc_end_radians() const;
 
   private:
     RadialGaugeConfig config_;
@@ -70,11 +90,31 @@ class RadialGaugeModel {
 class SparkLineModel {
   public:
     explicit SparkLineModel(SparkLineConfig config = {});
+
+    // Existing API — unchanged.
     [[nodiscard]] int buffer_len() const;
     [[nodiscard]] double latest() const;
     [[nodiscard]] bool has_data() const;
     void push(double value);
     void push_many(const std::vector<double>& values);
+
+    // Computed properties for rendering.
+
+    // Returns normalized values (0.0 to 1.0) for the entire buffer.
+    // Empty buffer returns an empty vector.
+    [[nodiscard]] std::vector<double> normalized_buffer() const;
+
+    // Returns the minimum value present in the current buffer.
+    // Returns 0.0 for an empty buffer.
+    [[nodiscard]] double buffer_min() const;
+
+    // Returns the maximum value present in the current buffer.
+    // Returns 0.0 for an empty buffer.
+    [[nodiscard]] double buffer_max() const;
+
+    // Returns fill opacity in [0.1, 0.9] scaled to the latest value (0-100).
+    // Returns 0.1 for an empty buffer.
+    [[nodiscard]] double fill_opacity() const;
 
   private:
     SparkLineConfig config_;
@@ -84,12 +124,32 @@ class SparkLineModel {
 class TimelineModel {
   public:
     explicit TimelineModel(TimelineConfig config = {});
+
+    // Existing API — unchanged.
     [[nodiscard]] int snapshot_count() const;
     [[nodiscard]] double scrub_ratio() const;
     [[nodiscard]] double scrub_timestamp() const;
     [[nodiscard]] bool has_scrub_timestamp() const;
     void set_data(const std::vector<TimelinePoint>& snapshots);
     void set_scrub_ratio(double ratio);
+
+    // Computed properties for rendering.
+
+    // Returns normalized CPU values (0.0 to 1.0) for all snapshots.
+    // Empty snapshot list returns an empty vector.
+    [[nodiscard]] std::vector<double> normalized_cpu() const;
+
+    // Returns normalized memory values (0.0 to 1.0) for all snapshots.
+    // Empty snapshot list returns an empty vector.
+    [[nodiscard]] std::vector<double> normalized_memory() const;
+
+    // Returns the timestamp of the earliest (first) snapshot.
+    // Returns 0.0 if there are no snapshots.
+    [[nodiscard]] double earliest_timestamp() const;
+
+    // Returns the timestamp of the latest (last) snapshot.
+    // Returns 0.0 if there are no snapshots.
+    [[nodiscard]] double latest_timestamp() const;
 
   private:
     TimelineConfig config_;

--- a/src/render/native/src/theme.cpp
+++ b/src/render/native/src/theme.cpp
@@ -39,7 +39,35 @@ char to_hex_char(int value) {
     return kHex[static_cast<std::size_t>(value)];
 }
 
+// Build a "#rrggbb" string from clamped 0-255 channel values.
+std::string rgb_to_hex(int red, int green, int blue) {
+    std::string out;
+    out.reserve(7);
+    out.push_back('#');
+    out.push_back(to_hex_char((red >> 4) & 0x0f));
+    out.push_back(to_hex_char(red & 0x0f));
+    out.push_back(to_hex_char((green >> 4) & 0x0f));
+    out.push_back(to_hex_char(green & 0x0f));
+    out.push_back(to_hex_char((blue >> 4) & 0x0f));
+    out.push_back(to_hex_char(blue & 0x0f));
+    return out;
+}
+
+// Linearise a single 8-bit sRGB channel for WCAG luminance computation.
+// Returns a value in [0, 1].
+double linearise_channel(int channel_8bit) {
+    const double c = static_cast<double>(channel_8bit) / 255.0;
+    if (c <= 0.04045) {
+        return c / 12.92;
+    }
+    return std::pow((c + 0.055) / 1.055, 2.4);
+}
+
 }  // namespace
+
+// ---------------------------------------------------------------------------
+// Existing API — unchanged
+// ---------------------------------------------------------------------------
 
 RgbColor parse_hex_color(const std::string& value) {
     if (value.size() != 7 || value.front() != '#') {
@@ -68,20 +96,99 @@ std::string blend_hex_color(const std::string& start, const std::string& end, do
         static_cast<double>(start_rgb.blue) + ((end_rgb.blue - start_rgb.blue) * t)
     ));
 
-    std::string out;
-    out.reserve(7);
-    out.push_back('#');
-    out.push_back(to_hex_char((red >> 4) & 0x0f));
-    out.push_back(to_hex_char(red & 0x0f));
-    out.push_back(to_hex_char((green >> 4) & 0x0f));
-    out.push_back(to_hex_char(green & 0x0f));
-    out.push_back(to_hex_char((blue >> 4) & 0x0f));
-    out.push_back(to_hex_char(blue & 0x0f));
-    return out;
+    return rgb_to_hex(red, green, blue);
 }
 
 int quantize_accent_intensity(double accent_intensity) {
     return static_cast<int>(std::lround(clamp_unit(accent_intensity) * 100.0));
+}
+
+// ---------------------------------------------------------------------------
+// Gauge color interpolation
+// ---------------------------------------------------------------------------
+
+// Blend two RgbColor values by ratio t in [0, 1].
+// Returns clamped integer channels.
+namespace {
+
+RgbColor blend_rgb(const RgbColor& a, const RgbColor& b, double t) {
+    const double tc = clamp_unit(t);
+    return RgbColor{
+        static_cast<int>(std::lround(
+            static_cast<double>(a.red)   + (static_cast<double>(b.red   - a.red)   * tc))),
+        static_cast<int>(std::lround(
+            static_cast<double>(a.green) + (static_cast<double>(b.green - a.green) * tc))),
+        static_cast<int>(std::lround(
+            static_cast<double>(a.blue)  + (static_cast<double>(b.blue  - a.blue)  * tc))),
+    };
+}
+
+}  // namespace
+
+RgbColor interpolate_gauge_color(double percent) {
+    // Guard against NaN / Inf — treat as 0.
+    if (!std::isfinite(percent)) {
+        percent = 0.0;
+    }
+    // Clamp to [0, 100].
+    if (percent < 0.0) {
+        percent = 0.0;
+    }
+    if (percent > 100.0) {
+        percent = 100.0;
+    }
+
+    // Pre-parsed palette stops.
+    static const RgbColor kBlue  = {0x3b, 0x82, 0xf6};  // #3b82f6
+    static const RgbColor kCyan  = {0x06, 0xb6, 0xd4};  // #06b6d4
+    static const RgbColor kAmber = {0xf5, 0x9e, 0x0b};  // #f59e0b
+    static const RgbColor kRed   = {0xef, 0x44, 0x44};  // #ef4444
+
+    // Segment boundaries
+    // [0, 40)   : flat blue
+    // [40, 70)  : blue -> cyan
+    // [70, 85)  : cyan -> amber
+    // [85, 100] : amber -> red
+
+    if (percent <= 40.0) {
+        return kBlue;
+    }
+    if (percent <= 70.0) {
+        const double t = (percent - 40.0) / 30.0;  // [0,1] over [40,70]
+        return blend_rgb(kBlue, kCyan, t);
+    }
+    if (percent <= 85.0) {
+        const double t = (percent - 70.0) / 15.0;  // [0,1] over [70,85]
+        return blend_rgb(kCyan, kAmber, t);
+    }
+    // (85, 100]
+    const double t = (percent - 85.0) / 15.0;  // [0,1] over [85,100]
+    return blend_rgb(kAmber, kRed, t);
+}
+
+std::string interpolate_gauge_color_hex(double percent) {
+    const RgbColor c = interpolate_gauge_color(percent);
+    return rgb_to_hex(c.red, c.green, c.blue);
+}
+
+// ---------------------------------------------------------------------------
+// Accessibility helpers (WCAG 2.x)
+// ---------------------------------------------------------------------------
+
+double relative_luminance(const RgbColor& color) {
+    const double r = linearise_channel(color.red);
+    const double g = linearise_channel(color.green);
+    const double b = linearise_channel(color.blue);
+    return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+double contrast_ratio(const RgbColor& foreground, const RgbColor& background) {
+    const double lf = relative_luminance(foreground);
+    const double lb = relative_luminance(background);
+    const double lighter = (lf > lb) ? lf : lb;
+    const double darker  = (lf > lb) ? lb : lf;
+    // Denominator is always >= 0.05, so no division-by-zero risk.
+    return (lighter + 0.05) / (darker + 0.05);
 }
 
 }  // namespace aura::render_native

--- a/src/render/native/src/widgets_models.cpp
+++ b/src/render/native/src/widgets_models.cpp
@@ -1,15 +1,18 @@
 #include "render_native/widgets_models.hpp"
 
 #include <algorithm>
+#include <cmath>
 #include <stdexcept>
 #include <utility>
 
 #include "render_native/math.hpp"
+#include "render_native/theme.hpp"
 
 namespace aura::render_native {
 
 namespace {
 
+// Clamp ratio to [0, 1].  Used by TimelineModel::set_scrub_ratio.
 double clamp_ratio(double value) {
     if (value < 0.0) {
         return 0.0;
@@ -20,7 +23,14 @@ double clamp_ratio(double value) {
     return value;
 }
 
+// Degrees to radians conversion factor.
+static constexpr double kDegToRad = 3.14159265358979323846 / 180.0;
+
 }  // namespace
+
+// ===========================================================================
+// RadialGaugeModel
+// ===========================================================================
 
 RadialGaugeModel::RadialGaugeModel(RadialGaugeConfig config) : config_(std::move(config)) {
     if (config_.sweep_degrees <= 0.0 || config_.sweep_degrees > 360.0) {
@@ -49,6 +59,35 @@ void RadialGaugeModel::set_value(double value) {
 void RadialGaugeModel::set_accent_intensity(double accent_intensity) {
     accent_intensity_ = clamp_unit(accent_intensity);
 }
+
+// ---------------------------------------------------------------------------
+// RadialGaugeModel — computed properties
+// ---------------------------------------------------------------------------
+
+double RadialGaugeModel::value_sweep_degrees() const {
+    // value_ is already clamped to [0, 100] by sanitize_percent.
+    // Map [0, 100] linearly onto [0, sweep_degrees].
+    return (value_ / 100.0) * config_.sweep_degrees;
+}
+
+RgbColor RadialGaugeModel::value_color() const {
+    return interpolate_gauge_color(value_);
+}
+
+double RadialGaugeModel::arc_start_radians() const {
+    // start_angle_degrees follows the Qt / Canvas convention:
+    //   0°   = 3-o'clock,  angles increase clockwise.
+    // We convert directly: positive = clockwise from 3-o'clock.
+    return config_.start_angle_degrees * kDegToRad;
+}
+
+double RadialGaugeModel::arc_end_radians() const {
+    return arc_start_radians() + (value_sweep_degrees() * kDegToRad);
+}
+
+// ===========================================================================
+// SparkLineModel
+// ===========================================================================
 
 SparkLineModel::SparkLineModel(SparkLineConfig config) : config_(std::move(config)) {
     if (config_.buffer_size < 2) {
@@ -89,6 +128,66 @@ void SparkLineModel::push_many(const std::vector<double>& values) {
         push(value);
     }
 }
+
+// ---------------------------------------------------------------------------
+// SparkLineModel — computed properties
+// ---------------------------------------------------------------------------
+
+double SparkLineModel::buffer_min() const {
+    if (buffer_.empty()) {
+        return 0.0;
+    }
+    return *std::min_element(buffer_.begin(), buffer_.end());
+}
+
+double SparkLineModel::buffer_max() const {
+    if (buffer_.empty()) {
+        return 0.0;
+    }
+    return *std::max_element(buffer_.begin(), buffer_.end());
+}
+
+std::vector<double> SparkLineModel::normalized_buffer() const {
+    if (buffer_.empty()) {
+        return {};
+    }
+
+    const double lo = buffer_min();
+    const double hi = buffer_max();
+    const double range = hi - lo;
+
+    std::vector<double> out;
+    out.reserve(buffer_.size());
+
+    if (range < 1e-9) {
+        // All values are effectively equal — map them all to 0.5 so the
+        // spark line still renders at mid-height rather than collapsing.
+        for (std::size_t i = 0; i < buffer_.size(); ++i) {
+            out.push_back(0.5);
+        }
+    } else {
+        for (const double v : buffer_) {
+            out.push_back(clamp_unit((v - lo) / range));
+        }
+    }
+    return out;
+}
+
+double SparkLineModel::fill_opacity() const {
+    // Map latest value [0, 100] linearly to opacity [0.1, 0.9].
+    // Empty buffer falls back to the minimum opacity.
+    static constexpr double kOpacityMin = 0.1;
+    static constexpr double kOpacityMax = 0.9;
+    if (buffer_.empty()) {
+        return kOpacityMin;
+    }
+    const double normalized = clamp_unit(latest() / 100.0);
+    return kOpacityMin + (normalized * (kOpacityMax - kOpacityMin));
+}
+
+// ===========================================================================
+// TimelineModel
+// ===========================================================================
 
 TimelineModel::TimelineModel(TimelineConfig config) : config_(std::move(config)) {
     if (config_.line_width <= 0.0) {
@@ -144,6 +243,49 @@ void TimelineModel::set_data(const std::vector<TimelinePoint>& snapshots) {
 
 void TimelineModel::set_scrub_ratio(double ratio) {
     scrub_ratio_ = clamp_ratio(ratio);
+}
+
+// ---------------------------------------------------------------------------
+// TimelineModel — computed properties
+// ---------------------------------------------------------------------------
+
+std::vector<double> TimelineModel::normalized_cpu() const {
+    if (snapshots_.empty()) {
+        return {};
+    }
+    std::vector<double> out;
+    out.reserve(snapshots_.size());
+    for (const auto& pt : snapshots_) {
+        // cpu_percent is stored as 0-100; normalize to [0, 1].
+        out.push_back(clamp_unit(pt.cpu_percent / 100.0));
+    }
+    return out;
+}
+
+std::vector<double> TimelineModel::normalized_memory() const {
+    if (snapshots_.empty()) {
+        return {};
+    }
+    std::vector<double> out;
+    out.reserve(snapshots_.size());
+    for (const auto& pt : snapshots_) {
+        out.push_back(clamp_unit(pt.memory_percent / 100.0));
+    }
+    return out;
+}
+
+double TimelineModel::earliest_timestamp() const {
+    if (snapshots_.empty()) {
+        return 0.0;
+    }
+    return snapshots_.front().timestamp;
+}
+
+double TimelineModel::latest_timestamp() const {
+    if (snapshots_.empty()) {
+        return 0.0;
+    }
+    return snapshots_.back().timestamp;
 }
 
 }  // namespace aura::render_native

--- a/src/shell/native/qml/CockpitScene.qml
+++ b/src/shell/native/qml/CockpitScene.qml
@@ -2,10 +2,11 @@ import QtQuick 2.15
 
 Rectangle {
     id: root
-    color: "#0d2034"
-    radius: 8
+    color: "#080e18"
+    radius: 10
     clip: true
 
+    // ── C++ bridge properties ────────────────────────────────────────────────
     property real accentIntensity: 0.0
     property real cpuPercent: 0.0
     property real memoryPercent: 0.0
@@ -21,165 +22,759 @@ Rectangle {
     property real memoryAlpha: 0.70
     property string statusText: "Waiting for telemetry..."
 
+    // ── Smoothed animated values used by Canvas gauges ───────────────────────
+    property real smoothCpu: 0.0
+    property real smoothMem: 0.0
+
+    Behavior on smoothCpu {
+        NumberAnimation { duration: 600; easing.type: Easing.OutCubic }
+    }
+    Behavior on smoothMem {
+        NumberAnimation { duration: 600; easing.type: Easing.OutCubic }
+    }
     Behavior on accentIntensity {
-        NumberAnimation { duration: 180; easing.type: Easing.OutCubic }
+        NumberAnimation { duration: 400; easing.type: Easing.OutCubic }
     }
 
-    Text {
-        id: titleLabel
-        text: "AURA COCKPIT"
-        anchors.horizontalCenter: parent.horizontalCenter
-        anchors.top: parent.top
-        anchors.topMargin: 14
-        color: "#d7ebff"
-        font.pixelSize: 18
-        font.weight: Font.DemiBold
-        font.letterSpacing: 2
+    onCpuPercentChanged:    { smoothCpu = cpuPercent;    cpuSparkCanvas.pushSample(cpuPercent) }
+    onMemoryPercentChanged: { smoothMem = memoryPercent; memSparkCanvas.pushSample(memoryPercent) }
+
+    // ── Derived accent color helpers ─────────────────────────────────────────
+    function accentColor(alpha) {
+        return Qt.rgba(accentRed, accentGreen, accentBlue, alpha)
     }
 
-    Row {
-        id: gaugeRow
-        anchors.horizontalCenter: parent.horizontalCenter
-        anchors.top: titleLabel.bottom
-        anchors.topMargin: 20
-        spacing: 40
-
-        Item {
-            id: cpuGauge
-            width: Math.min(root.width * 0.28, 160)
-            height: width
-
-            Rectangle {
-                id: cpuRing
-                anchors.centerIn: parent
-                width: parent.width
-                height: width
-                radius: width / 2
-                color: "transparent"
-                border.width: root.ringLineWidth
-                border.color: Qt.rgba(
-                    root.accentRed,
-                    root.accentGreen,
-                    root.accentBlue,
-                    Math.min(1.0, root.cpuAlpha + root.ringGlowStrength * 0.20)
-                )
-
-                Behavior on border.width {
-                    NumberAnimation { duration: 200; easing.type: Easing.OutQuad }
-                }
-                Behavior on border.color {
-                    ColorAnimation { duration: 300 }
-                }
-            }
-
-            Column {
-                anchors.centerIn: parent
-                spacing: 2
-
-                Text {
-                    text: "CPU"
-                    anchors.horizontalCenter: parent.horizontalCenter
-                    color: "#9fc8e8"
-                    font.pixelSize: 11
-                    font.weight: Font.Medium
-                    font.letterSpacing: 1
-                }
-
-                Text {
-                    text: root.cpuPercent.toFixed(1) + "%"
-                    anchors.horizontalCenter: parent.horizontalCenter
-                    color: "#e0f0ff"
-                    font.pixelSize: 22
-                    font.weight: Font.Bold
-                }
-            }
+    // Gauge arc color: 0–50 = blue→cyan, 50–80 = cyan→amber, 80–100 = amber→red
+    function gaugeColor(pct, alpha) {
+        var t, r, g, b
+        if (pct <= 50) {
+            t = pct / 50.0
+            r = 0.231 + (0.024 - 0.231) * t   // #3b82f6 → #06b6d4
+            g = 0.510 + (0.714 - 0.510) * t
+            b = 0.965 + (0.831 - 0.965) * t
+        } else if (pct <= 80) {
+            t = (pct - 50) / 30.0
+            r = 0.024 + (0.961 - 0.024) * t   // #06b6d4 → #f59e0b
+            g = 0.714 + (0.620 - 0.714) * t
+            b = 0.831 + (0.043 - 0.831) * t
+        } else {
+            t = (pct - 80) / 20.0
+            r = 0.961 + (0.937 - 0.961) * t   // #f59e0b → #ef4444
+            g = 0.620 + (0.267 - 0.620) * t
+            b = 0.043 + (0.267 - 0.043) * t
         }
-
-        Item {
-            id: memGauge
-            width: Math.min(root.width * 0.28, 160)
-            height: width
-
-            Rectangle {
-                id: memRing
-                anchors.centerIn: parent
-                width: parent.width
-                height: width
-                radius: width / 2
-                color: "transparent"
-                border.width: root.ringLineWidth
-                border.color: Qt.rgba(
-                    root.accentRed,
-                    root.accentGreen,
-                    root.accentBlue,
-                    Math.min(1.0, root.memoryAlpha + root.ringGlowStrength * 0.20)
-                )
-
-                Behavior on border.width {
-                    NumberAnimation { duration: 200; easing.type: Easing.OutQuad }
-                }
-                Behavior on border.color {
-                    ColorAnimation { duration: 300 }
-                }
-            }
-
-            Column {
-                anchors.centerIn: parent
-                spacing: 2
-
-                Text {
-                    text: "MEM"
-                    anchors.horizontalCenter: parent.horizontalCenter
-                    color: "#9fc8e8"
-                    font.pixelSize: 11
-                    font.weight: Font.Medium
-                    font.letterSpacing: 1
-                }
-
-                Text {
-                    text: root.memoryPercent.toFixed(1) + "%"
-                    anchors.horizontalCenter: parent.horizontalCenter
-                    color: "#e0f0ff"
-                    font.pixelSize: 22
-                    font.weight: Font.Bold
-                }
-            }
-        }
+        return Qt.rgba(
+            Math.max(0, Math.min(1, r)),
+            Math.max(0, Math.min(1, g)),
+            Math.max(0, Math.min(1, b)),
+            alpha
+        )
     }
 
+    // ── Gauge size ────────────────────────────────────────────────────────────
+    property real gaugeSize: Math.min(Math.max(root.width * 0.30, 110), 160)
+
+    // ── Layout constants ──────────────────────────────────────────────────────
+    property real margin: 20
+
+    // =========================================================================
+    // LAYER 0 — background vignette / depth
+    // =========================================================================
     Rectangle {
-        id: divider
-        anchors.horizontalCenter: parent.horizontalCenter
-        anchors.top: gaugeRow.bottom
-        anchors.topMargin: 16
-        width: parent.width * 0.75
-        height: 1
-        color: Qt.rgba(root.accentRed, root.accentGreen, root.accentBlue, 0.20 + root.frostIntensity * 0.40)
-    }
-
-    Text {
-        id: statusLabel
-        text: root.statusText
-        anchors.horizontalCenter: parent.horizontalCenter
-        anchors.top: divider.bottom
-        anchors.topMargin: 12
-        color: "#9fc8e8"
-        font.pixelSize: 12
-        elide: Text.ElideRight
-        width: parent.width * 0.85
-        horizontalAlignment: Text.AlignHCenter
-    }
-
-    Rectangle {
-        id: accentGlow
         anchors.fill: parent
-        color: "transparent"
-        border.width: 2
-        border.color: Qt.rgba(root.accentRed, root.accentGreen, root.accentBlue, root.accentAlpha)
         radius: root.radius
+        gradient: Gradient {
+            GradientStop { position: 0.0; color: "#0c1829" }
+            GradientStop { position: 0.55; color: "#080e18" }
+            GradientStop { position: 1.0; color: "#050a11" }
+        }
+    }
+
+    // Corner vignette — top fade
+    Rectangle {
+        anchors { left: parent.left; right: parent.right; top: parent.top }
+        height: parent.height * 0.35
+        radius: root.radius
+        gradient: Gradient {
+            GradientStop { position: 0.0; color: Qt.rgba(root.accentRed * 0.5, root.accentGreen * 0.5, root.accentBlue * 0.5, 0.06 + root.accentIntensity * 0.04) }
+            GradientStop { position: 1.0; color: "transparent" }
+        }
+    }
+
+    // =========================================================================
+    // LAYER 1 — frosted-glass panel surface
+    // =========================================================================
+    Rectangle {
+        id: panelSurface
+        anchors { fill: parent; margins: 1 }
+        radius: root.radius - 1
+        color: Qt.rgba(root.accentRed * 0.08, root.accentGreen * 0.08, root.accentBlue * 0.12,
+                       0.18 + root.frostIntensity * 0.25)
+        border.width: 1
+        border.color: Qt.rgba(root.accentRed, root.accentGreen, root.accentBlue,
+                              0.12 + root.accentIntensity * 0.10)
+    }
+
+    // =========================================================================
+    // CONTENT COLUMN
+    // =========================================================================
+    Column {
+        id: contentColumn
+        anchors { left: parent.left; right: parent.right; top: parent.top; topMargin: root.margin }
+        spacing: 0
+
+        // ── Title band ───────────────────────────────────────────────────────
+        Item {
+            width: parent.width
+            height: 28
+
+            Text {
+                id: titleLabel
+                text: "AURA  COCKPIT"
+                anchors.centerIn: parent
+                color: "#4a6d8a"
+                font.pixelSize: 11
+                font.weight: Font.Medium
+                font.letterSpacing: 4
+            }
+
+            // Subtle title underline glow
+            Rectangle {
+                anchors { horizontalCenter: parent.horizontalCenter; bottom: parent.bottom }
+                width: titleLabel.width * 0.6
+                height: 1
+                color: root.accentColor(0.20 + root.accentIntensity * 0.15)
+            }
+        }
+
+        Item { width: 1; height: 14 } // spacer
+
+        // ── Gauge pair ───────────────────────────────────────────────────────
+        Row {
+            id: gaugeRow
+            anchors.horizontalCenter: parent.horizontalCenter
+            spacing: Math.max(root.width * 0.08, 24)
+
+            // ── CPU gauge ────────────────────────────────────────────────────
+            Item {
+                id: cpuGaugeItem
+                width: root.gaugeSize
+                height: root.gaugeSize
+
+                // Outer glow halo — drawn first (behind)
+                Canvas {
+                    id: cpuGlowCanvas
+                    anchors.centerIn: parent
+                    width: parent.width + 24
+                    height: parent.height + 24
+                    opacity: 0.35 + root.accentIntensity * 0.20
+
+                    onPaint: {
+                        var ctx = getContext("2d")
+                        ctx.clearRect(0, 0, width, height)
+                        var cx = width / 2
+                        var cy = height / 2
+                        var r  = (parent.width / 2) + 6
+                        var startAngle = Math.PI * 0.75
+                        var sweepAngle = Math.PI * 1.50 * (root.smoothCpu / 100.0)
+
+                        var gc = root.gaugeColor(root.smoothCpu, 1.0)
+                        ctx.beginPath()
+                        ctx.arc(cx, cy, r, startAngle, startAngle + sweepAngle, false)
+                        ctx.strokeStyle = Qt.rgba(gc.r, gc.g, gc.b, 0.30)
+                        ctx.lineWidth   = 18
+                        ctx.lineCap     = "round"
+                        ctx.stroke()
+                    }
+
+                    Connections {
+                        target: root
+                        function onSmoothCpuChanged() { cpuGlowCanvas.requestPaint() }
+                        function onAccentIntensityChanged() { cpuGlowCanvas.requestPaint() }
+                    }
+                }
+
+                // Main arc gauge canvas
+                Canvas {
+                    id: cpuArcCanvas
+                    anchors.centerIn: parent
+                    width:  parent.width
+                    height: parent.height
+
+                    onPaint: {
+                        var ctx = getContext("2d")
+                        ctx.clearRect(0, 0, width, height)
+
+                        var cx = width  / 2
+                        var cy = height / 2
+                        var r  = width  / 2 - 10
+                        var trackW = 11
+                        var startAngle = Math.PI * 0.75            // 135°
+                        var fullSweep  = Math.PI * 1.50            // 270°
+                        var endAngle   = startAngle + fullSweep * (root.smoothCpu / 100.0)
+
+                        // Track arc
+                        ctx.beginPath()
+                        ctx.arc(cx, cy, r, startAngle, startAngle + fullSweep, false)
+                        ctx.strokeStyle = "#1a2940"
+                        ctx.lineWidth   = trackW
+                        ctx.lineCap     = "butt"
+                        ctx.stroke()
+
+                        // Tick marks at 25%, 50%, 75%
+                        ctx.strokeStyle = "#0c1829"
+                        ctx.lineWidth   = 2
+                        var ticks = [0.25, 0.50, 0.75]
+                        for (var i = 0; i < ticks.length; i++) {
+                            var ta = startAngle + fullSweep * ticks[i]
+                            ctx.beginPath()
+                            ctx.arc(cx, cy, r, ta, ta + 0.012, false)
+                            ctx.lineWidth = trackW + 2
+                            ctx.stroke()
+                        }
+
+                        // Value arc
+                        if (root.smoothCpu > 0.2) {
+                            var gc = root.gaugeColor(root.smoothCpu, 1.0)
+                            var grad = ctx.createLinearGradient(
+                                cx + r * Math.cos(startAngle),
+                                cy + r * Math.sin(startAngle),
+                                cx + r * Math.cos(endAngle),
+                                cy + r * Math.sin(endAngle)
+                            )
+                            var gcStart = root.gaugeColor(Math.max(0, root.smoothCpu * 0.5), 1.0)
+                            grad.addColorStop(0.0, Qt.rgba(gcStart.r, gcStart.g, gcStart.b, 0.85))
+                            grad.addColorStop(1.0, Qt.rgba(gc.r,      gc.g,      gc.b,      1.00))
+
+                            ctx.beginPath()
+                            ctx.arc(cx, cy, r, startAngle, endAngle, false)
+                            ctx.strokeStyle = grad
+                            ctx.lineWidth   = trackW
+                            ctx.lineCap     = "round"
+                            ctx.stroke()
+
+                            // Leading dot highlight
+                            var dotX = cx + r * Math.cos(endAngle)
+                            var dotY = cy + r * Math.sin(endAngle)
+                            ctx.beginPath()
+                            ctx.arc(dotX, dotY, trackW * 0.55, 0, Math.PI * 2, false)
+                            ctx.fillStyle = Qt.rgba(gc.r, gc.g, gc.b, 1.0)
+                            ctx.fill()
+                        }
+                    }
+
+                    Connections {
+                        target: root
+                        function onSmoothCpuChanged() { cpuArcCanvas.requestPaint() }
+                        function onAccentIntensityChanged() { cpuArcCanvas.requestPaint() }
+                    }
+                }
+
+                // Center text
+                Column {
+                    anchors.centerIn: parent
+                    anchors.verticalCenterOffset: 4
+                    spacing: 2
+
+                    Text {
+                        anchors.horizontalCenter: parent.horizontalCenter
+                        text: root.cpuPercent.toFixed(0) + "%"
+                        color: "#e8f4ff"
+                        font.pixelSize: Math.max(22, root.gaugeSize * 0.20)
+                        font.weight: Font.Bold
+                    }
+
+                    Text {
+                        anchors.horizontalCenter: parent.horizontalCenter
+                        text: "CPU"
+                        color: "#7ba8c8"
+                        font.pixelSize: 9
+                        font.weight: Font.Medium
+                        font.letterSpacing: 2.5
+                    }
+                }
+            }
+
+            // ── Memory gauge ─────────────────────────────────────────────────
+            Item {
+                id: memGaugeItem
+                width: root.gaugeSize
+                height: root.gaugeSize
+
+                // Outer glow halo
+                Canvas {
+                    id: memGlowCanvas
+                    anchors.centerIn: parent
+                    width: parent.width + 24
+                    height: parent.height + 24
+                    opacity: 0.35 + root.accentIntensity * 0.20
+
+                    onPaint: {
+                        var ctx = getContext("2d")
+                        ctx.clearRect(0, 0, width, height)
+                        var cx = width / 2
+                        var cy = height / 2
+                        var r  = (parent.width / 2) + 6
+                        var startAngle = Math.PI * 0.75
+                        var sweepAngle = Math.PI * 1.50 * (root.smoothMem / 100.0)
+
+                        var gc = root.gaugeColor(root.smoothMem, 1.0)
+                        ctx.beginPath()
+                        ctx.arc(cx, cy, r, startAngle, startAngle + sweepAngle, false)
+                        ctx.strokeStyle = Qt.rgba(gc.r, gc.g, gc.b, 0.30)
+                        ctx.lineWidth   = 18
+                        ctx.lineCap     = "round"
+                        ctx.stroke()
+                    }
+
+                    Connections {
+                        target: root
+                        function onSmoothMemChanged() { memGlowCanvas.requestPaint() }
+                        function onAccentIntensityChanged() { memGlowCanvas.requestPaint() }
+                    }
+                }
+
+                Canvas {
+                    id: memArcCanvas
+                    anchors.centerIn: parent
+                    width:  parent.width
+                    height: parent.height
+
+                    onPaint: {
+                        var ctx = getContext("2d")
+                        ctx.clearRect(0, 0, width, height)
+
+                        var cx = width  / 2
+                        var cy = height / 2
+                        var r  = width  / 2 - 10
+                        var trackW = 11
+                        var startAngle = Math.PI * 0.75
+                        var fullSweep  = Math.PI * 1.50
+                        var endAngle   = startAngle + fullSweep * (root.smoothMem / 100.0)
+
+                        // Track arc
+                        ctx.beginPath()
+                        ctx.arc(cx, cy, r, startAngle, startAngle + fullSweep, false)
+                        ctx.strokeStyle = "#1a2940"
+                        ctx.lineWidth   = trackW
+                        ctx.lineCap     = "butt"
+                        ctx.stroke()
+
+                        // Tick marks
+                        ctx.strokeStyle = "#0c1829"
+                        var ticks = [0.25, 0.50, 0.75]
+                        for (var i = 0; i < ticks.length; i++) {
+                            var ta = startAngle + fullSweep * ticks[i]
+                            ctx.beginPath()
+                            ctx.arc(cx, cy, r, ta, ta + 0.012, false)
+                            ctx.lineWidth = trackW + 2
+                            ctx.stroke()
+                        }
+
+                        // Value arc
+                        if (root.smoothMem > 0.2) {
+                            var gc = root.gaugeColor(root.smoothMem, 1.0)
+                            var grad = ctx.createLinearGradient(
+                                cx + r * Math.cos(startAngle),
+                                cy + r * Math.sin(startAngle),
+                                cx + r * Math.cos(endAngle),
+                                cy + r * Math.sin(endAngle)
+                            )
+                            var gcStart = root.gaugeColor(Math.max(0, root.smoothMem * 0.5), 1.0)
+                            grad.addColorStop(0.0, Qt.rgba(gcStart.r, gcStart.g, gcStart.b, 0.85))
+                            grad.addColorStop(1.0, Qt.rgba(gc.r,      gc.g,      gc.b,      1.00))
+
+                            ctx.beginPath()
+                            ctx.arc(cx, cy, r, startAngle, endAngle, false)
+                            ctx.strokeStyle = grad
+                            ctx.lineWidth   = trackW
+                            ctx.lineCap     = "round"
+                            ctx.stroke()
+
+                            // Leading dot
+                            var dotX = cx + r * Math.cos(endAngle)
+                            var dotY = cy + r * Math.sin(endAngle)
+                            ctx.beginPath()
+                            ctx.arc(dotX, dotY, trackW * 0.55, 0, Math.PI * 2, false)
+                            ctx.fillStyle = Qt.rgba(gc.r, gc.g, gc.b, 1.0)
+                            ctx.fill()
+                        }
+                    }
+
+                    Connections {
+                        target: root
+                        function onSmoothMemChanged() { memArcCanvas.requestPaint() }
+                        function onAccentIntensityChanged() { memArcCanvas.requestPaint() }
+                    }
+                }
+
+                // Center text
+                Column {
+                    anchors.centerIn: parent
+                    anchors.verticalCenterOffset: 4
+                    spacing: 2
+
+                    Text {
+                        anchors.horizontalCenter: parent.horizontalCenter
+                        text: root.memoryPercent.toFixed(0) + "%"
+                        color: "#e8f4ff"
+                        font.pixelSize: Math.max(22, root.gaugeSize * 0.20)
+                        font.weight: Font.Bold
+                    }
+
+                    Text {
+                        anchors.horizontalCenter: parent.horizontalCenter
+                        text: "MEM"
+                        color: "#7ba8c8"
+                        font.pixelSize: 9
+                        font.weight: Font.Medium
+                        font.letterSpacing: 2.5
+                    }
+                }
+            }
+        } // Row gaugeRow
+
+        Item { width: 1; height: 16 } // spacer
+
+        // ── Section divider ──────────────────────────────────────────────────
+        Item {
+            width: parent.width
+            height: 1
+
+            Rectangle {
+                anchors.centerIn: parent
+                width: parent.width * 0.82
+                height: 1
+                gradient: Gradient {
+                    orientation: Gradient.Horizontal
+                    GradientStop { position: 0.0; color: "transparent" }
+                    GradientStop { position: 0.2; color: root.accentColor(0.15 + root.accentIntensity * 0.08) }
+                    GradientStop { position: 0.8; color: root.accentColor(0.15 + root.accentIntensity * 0.08) }
+                    GradientStop { position: 1.0; color: "transparent" }
+                }
+            }
+        }
+
+        Item { width: 1; height: 14 } // spacer
+
+        // ── Sparkline — CPU ──────────────────────────────────────────────────
+        Item {
+            id: cpuSparkRow
+            anchors { left: parent.left; right: parent.right; leftMargin: root.margin; rightMargin: root.margin }
+            height: 64
+
+            // Label row
+            Text {
+                id: cpuSparkLabel
+                anchors { left: parent.left; verticalCenter: undefined; top: parent.top }
+                text: "CPU  HISTORY"
+                color: "#4a6d8a"
+                font.pixelSize: 9
+                font.weight: Font.Medium
+                font.letterSpacing: 2.5
+            }
+
+            Text {
+                anchors { right: parent.right; top: parent.top }
+                text: root.cpuPercent.toFixed(1) + "%"
+                color: root.gaugeColor(root.cpuPercent, 1.0)
+                font.pixelSize: 10
+                font.weight: Font.Bold
+                font.letterSpacing: 0.5
+            }
+
+            // Chart canvas
+            Canvas {
+                id: cpuSparkCanvas
+                anchors { left: parent.left; right: parent.right; bottom: parent.bottom }
+                height: parent.height - 18
+
+                property var samples: []
+
+                function pushSample(val) {
+                    samples.push(val)
+                    if (samples.length > 120) samples.shift()
+                    requestPaint()
+                }
+
+                onPaint: {
+                    var ctx = getContext("2d")
+                    ctx.clearRect(0, 0, width, height)
+                    if (samples.length < 2) return
+
+                    var n   = samples.length
+                    var pad = 2
+                    var cw  = width
+                    var ch  = height - pad
+
+                    // Build point array
+                    var pts = []
+                    for (var i = 0; i < n; i++) {
+                        var x = (i / (n - 1)) * cw
+                        var y = ch - (samples[i] / 100.0) * ch + pad
+                        pts.push({x: x, y: y})
+                    }
+
+                    // Filled gradient area
+                    ctx.beginPath()
+                    ctx.moveTo(pts[0].x, pts[0].y)
+                    for (var j = 1; j < n - 1; j++) {
+                        var mx = (pts[j].x + pts[j+1].x) / 2
+                        var my = (pts[j].y + pts[j+1].y) / 2
+                        ctx.quadraticCurveTo(pts[j].x, pts[j].y, mx, my)
+                    }
+                    ctx.lineTo(pts[n-1].x, pts[n-1].y)
+                    ctx.lineTo(cw, ch + pad)
+                    ctx.lineTo(0, ch + pad)
+                    ctx.closePath()
+
+                    var acR = root.accentRed
+                    var acG = root.accentGreen
+                    var acB = root.accentBlue
+                    var fillGrad = ctx.createLinearGradient(0, 0, 0, ch)
+                    fillGrad.addColorStop(0.0, Qt.rgba(acR, acG, acB, 0.28))
+                    fillGrad.addColorStop(1.0, Qt.rgba(acR, acG, acB, 0.02))
+                    ctx.fillStyle   = fillGrad
+                    ctx.fill()
+
+                    // Crisp line on top
+                    ctx.beginPath()
+                    ctx.moveTo(pts[0].x, pts[0].y)
+                    for (var k = 1; k < n - 1; k++) {
+                        var lmx = (pts[k].x + pts[k+1].x) / 2
+                        var lmy = (pts[k].y + pts[k+1].y) / 2
+                        ctx.quadraticCurveTo(pts[k].x, pts[k].y, lmx, lmy)
+                    }
+                    ctx.lineTo(pts[n-1].x, pts[n-1].y)
+                    ctx.strokeStyle = Qt.rgba(acR, acG, acB, 0.70)
+                    ctx.lineWidth   = 1.5
+                    ctx.lineJoin    = "round"
+                    ctx.stroke()
+
+                    // Latest value dot
+                    var lp = pts[n-1]
+                    ctx.beginPath()
+                    ctx.arc(lp.x, lp.y, 2.5, 0, Math.PI * 2, false)
+                    ctx.fillStyle = Qt.rgba(acR, acG, acB, 1.0)
+                    ctx.fill()
+                }
+
+                Connections {
+                    target: root
+                    function onAccentRedChanged()   { cpuSparkCanvas.requestPaint() }
+                    function onAccentGreenChanged() { cpuSparkCanvas.requestPaint() }
+                    function onAccentBlueChanged()  { cpuSparkCanvas.requestPaint() }
+                }
+            }
+        }
+
+        Item { width: 1; height: 8 } // spacer
+
+        // ── Sparkline — Memory ───────────────────────────────────────────────
+        Item {
+            id: memSparkRow
+            anchors { left: parent.left; right: parent.right; leftMargin: root.margin; rightMargin: root.margin }
+            height: 64
+
+            Text {
+                anchors { left: parent.left; top: parent.top }
+                text: "MEM  HISTORY"
+                color: "#4a6d8a"
+                font.pixelSize: 9
+                font.weight: Font.Medium
+                font.letterSpacing: 2.5
+            }
+
+            Text {
+                anchors { right: parent.right; top: parent.top }
+                text: root.memoryPercent.toFixed(1) + "%"
+                color: root.gaugeColor(root.memoryPercent, 1.0)
+                font.pixelSize: 10
+                font.weight: Font.Bold
+                font.letterSpacing: 0.5
+            }
+
+            Canvas {
+                id: memSparkCanvas
+                anchors { left: parent.left; right: parent.right; bottom: parent.bottom }
+                height: parent.height - 18
+
+                property var samples: []
+
+                function pushSample(val) {
+                    samples.push(val)
+                    if (samples.length > 120) samples.shift()
+                    requestPaint()
+                }
+
+                onPaint: {
+                    var ctx = getContext("2d")
+                    ctx.clearRect(0, 0, width, height)
+                    if (samples.length < 2) return
+
+                    var n   = samples.length
+                    var pad = 2
+                    var cw  = width
+                    var ch  = height - pad
+
+                    var pts = []
+                    for (var i = 0; i < n; i++) {
+                        var x = (i / (n - 1)) * cw
+                        var y = ch - (samples[i] / 100.0) * ch + pad
+                        pts.push({x: x, y: y})
+                    }
+
+                    // Filled area — memory uses a slightly warmer tint to visually separate
+                    ctx.beginPath()
+                    ctx.moveTo(pts[0].x, pts[0].y)
+                    for (var j = 1; j < n - 1; j++) {
+                        var mx = (pts[j].x + pts[j+1].x) / 2
+                        var my = (pts[j].y + pts[j+1].y) / 2
+                        ctx.quadraticCurveTo(pts[j].x, pts[j].y, mx, my)
+                    }
+                    ctx.lineTo(pts[n-1].x, pts[n-1].y)
+                    ctx.lineTo(cw, ch + pad)
+                    ctx.lineTo(0, ch + pad)
+                    ctx.closePath()
+
+                    // Memory sparkline: tint shifted toward cyan regardless of accent
+                    var fillGrad = ctx.createLinearGradient(0, 0, 0, ch)
+                    fillGrad.addColorStop(0.0, Qt.rgba(0.15, 0.65, 0.78, 0.28))
+                    fillGrad.addColorStop(1.0, Qt.rgba(0.15, 0.65, 0.78, 0.02))
+                    ctx.fillStyle = fillGrad
+                    ctx.fill()
+
+                    ctx.beginPath()
+                    ctx.moveTo(pts[0].x, pts[0].y)
+                    for (var k = 1; k < n - 1; k++) {
+                        var lmx = (pts[k].x + pts[k+1].x) / 2
+                        var lmy = (pts[k].y + pts[k+1].y) / 2
+                        ctx.quadraticCurveTo(pts[k].x, pts[k].y, lmx, lmy)
+                    }
+                    ctx.lineTo(pts[n-1].x, pts[n-1].y)
+                    ctx.strokeStyle = Qt.rgba(0.15, 0.65, 0.78, 0.70)
+                    ctx.lineWidth   = 1.5
+                    ctx.lineJoin    = "round"
+                    ctx.stroke()
+
+                    // Latest dot
+                    var lp = pts[n-1]
+                    ctx.beginPath()
+                    ctx.arc(lp.x, lp.y, 2.5, 0, Math.PI * 2, false)
+                    ctx.fillStyle = Qt.rgba(0.15, 0.65, 0.78, 1.0)
+                    ctx.fill()
+                }
+            }
+        }
+
+        Item { width: 1; height: 10 } // spacer
+
+        // ── Final divider ────────────────────────────────────────────────────
+        Item {
+            width: parent.width
+            height: 1
+
+            Rectangle {
+                anchors.centerIn: parent
+                width: parent.width * 0.82
+                height: 1
+                gradient: Gradient {
+                    orientation: Gradient.Horizontal
+                    GradientStop { position: 0.0; color: "transparent" }
+                    GradientStop { position: 0.2; color: root.accentColor(0.12 + root.frostIntensity * 0.06) }
+                    GradientStop { position: 0.8; color: root.accentColor(0.12 + root.frostIntensity * 0.06) }
+                    GradientStop { position: 1.0; color: "transparent" }
+                }
+            }
+        }
+
+        Item { width: 1; height: 10 } // spacer
+
+        // ── Status line ──────────────────────────────────────────────────────
+        Row {
+            anchors.horizontalCenter: parent.horizontalCenter
+            spacing: 6
+
+            // Pulse indicator dot
+            Rectangle {
+                id: statusDot
+                width: 5
+                height: 5
+                radius: 3
+                anchors.verticalCenter: parent.verticalCenter
+                color: root.accentColor(0.60 + root.accentIntensity * 0.40)
+
+                SequentialAnimation on opacity {
+                    running: true
+                    loops: Animation.Infinite
+                    NumberAnimation { to: 0.25; duration: 900; easing.type: Easing.InOutSine }
+                    NumberAnimation { to: 1.00; duration: 900; easing.type: Easing.InOutSine }
+                }
+            }
+
+            Text {
+                id: statusLabel
+                text: root.statusText
+                color: "#4a6d8a"
+                font.pixelSize: 10
+                font.letterSpacing: 0.5
+                elide: Text.ElideRight
+                width: root.width * 0.75
+                horizontalAlignment: Text.AlignLeft
+            }
+        }
+
+        Item { width: 1; height: root.margin } // bottom padding
+    } // contentColumn
+
+    // =========================================================================
+    // OUTER FRAME — accent border glow (drawn last, on top)
+    // =========================================================================
+    Rectangle {
+        id: outerFrame
+        anchors.fill: parent
+        radius: root.radius
+        color: "transparent"
+        border.width: 1
+        border.color: root.accentColor(
+            Math.min(0.45, root.accentAlpha + root.accentIntensity * 0.20)
+        )
 
         Behavior on border.color {
-            ColorAnimation { duration: 250 }
+            ColorAnimation { duration: 400; easing.type: Easing.OutCubic }
+        }
+    }
+
+    // Inner highlight edge — top-left corner catch-light
+    Rectangle {
+        anchors { left: parent.left; right: parent.right; top: parent.top }
+        height: 1
+        radius: root.radius
+        gradient: Gradient {
+            orientation: Gradient.Horizontal
+            GradientStop { position: 0.0; color: "transparent" }
+            GradientStop { position: 0.3; color: Qt.rgba(root.accentRed, root.accentGreen, root.accentBlue, 0.18 + root.accentIntensity * 0.10) }
+            GradientStop { position: 0.7; color: Qt.rgba(root.accentRed, root.accentGreen, root.accentBlue, 0.18 + root.accentIntensity * 0.10) }
+            GradientStop { position: 1.0; color: "transparent" }
+        }
+    }
+
+    // =========================================================================
+    // ACCENT GLOW PULSE — breathing border at high accentIntensity
+    // =========================================================================
+    Rectangle {
+        anchors.fill: parent
+        radius: root.radius
+        color: "transparent"
+        border.width: Math.max(0, root.accentIntensity * 3.0)
+        border.color: root.accentColor(root.accentIntensity * 0.18)
+        opacity: 0.8
+
+        Behavior on border.width {
+            NumberAnimation { duration: 400; easing.type: Easing.OutCubic }
+        }
+        Behavior on border.color {
+            ColorAnimation { duration: 400; easing.type: Easing.OutCubic }
         }
     }
 }

--- a/src/shell/native/src/main.cpp
+++ b/src/shell/native/src/main.cpp
@@ -2,6 +2,7 @@
 #include <QCommandLineOption>
 #include <QCommandLineParser>
 #include <QEvent>
+#include <QFont>
 #include <QFrame>
 #include <QHBoxLayout>
 #include <QLabel>
@@ -11,6 +12,8 @@
 #include <QPushButton>
 #include <QQuickItem>
 #include <QQuickWidget>
+#include <QScrollArea>
+#include <QSizePolicy>
 #include <QStackedWidget>
 #include <QTabBar>
 #include <QTimer>
@@ -33,6 +36,26 @@
 #include "aura_shell/timeline_bridge.hpp"
 
 namespace {
+
+// ---------------------------------------------------------------------------
+// Color palette — all depth levels and accent colors in one place so the
+// stylesheet strings below stay readable and consistent.
+// ---------------------------------------------------------------------------
+//  Depth 0  (window bg)  : #060b14
+//  Depth 1  (panels)     : #0a1221
+//  Depth 2  (surfaces)   : #0f1a2e
+//  Depth 3  (elevated)   : #162238
+//  Border subtle         : #1e3350
+//  Border active         : #2a4a6e
+//  Text primary          : #e0ecf7
+//  Text secondary        : #8badc4
+//  Text muted            : #4d6d87
+//  Accent blue           : #3b82f6
+//  Accent blue hover     : #60a5fa
+//  Danger (close)        : #ef4444
+//  Danger hover          : #f87171
+
+// ---------------------------------------------------------------------------
 
 struct LaunchConfig {
     double interval_seconds{1.0};
@@ -161,6 +184,338 @@ struct SlotWidgets {
     QStackedWidget* stack;
 };
 
+// ---------------------------------------------------------------------------
+// Comprehensive application stylesheet
+// ---------------------------------------------------------------------------
+static const QString k_app_stylesheet = QStringLiteral(
+    // --- Application-wide base ---
+    "* {"
+    "    font-family: 'Segoe UI';"
+    "    font-size: 11px;"
+    "    color: #e0ecf7;"
+    "}"
+
+    // --- Main window ---
+    "QMainWindow {"
+    "    background: #060b14;"
+    "}"
+
+    // --- Title bar ---
+    "QFrame#titlebar {"
+    "    background: qlineargradient("
+    "        x1:0, y1:0, x2:0, y2:1,"
+    "        stop:0 #0f1a2e,"
+    "        stop:1 #0a1221"
+    "    );"
+    "    border-bottom: 1px solid #1e3350;"
+    "    min-height: 36px;"
+    "    max-height: 36px;"
+    "}"
+
+    // --- App logo label in title bar ---
+    "QLabel#appLogo {"
+    "    color: #3b82f6;"
+    "    font-size: 13px;"
+    "    font-weight: 600;"
+    "    letter-spacing: 2px;"
+    "    padding-left: 4px;"
+    "}"
+
+    // --- Title bar subtitle ---
+    "QLabel#titleSubtitle {"
+    "    color: #4d6d87;"
+    "    font-size: 10px;"
+    "    letter-spacing: 1px;"
+    "    padding-left: 8px;"
+    "}"
+
+    // --- Title bar window-control buttons ---
+    "QPushButton#minBtn, QPushButton#maxBtn {"
+    "    background: transparent;"
+    "    color: #8badc4;"
+    "    border: none;"
+    "    border-radius: 4px;"
+    "    min-width: 28px;"
+    "    max-width: 28px;"
+    "    min-height: 24px;"
+    "    max-height: 24px;"
+    "    font-size: 13px;"
+    "    padding: 0px;"
+    "}"
+    "QPushButton#minBtn:hover {"
+    "    background: #162238;"
+    "    color: #e0ecf7;"
+    "}"
+    "QPushButton#maxBtn:hover {"
+    "    background: #162238;"
+    "    color: #e0ecf7;"
+    "}"
+    "QPushButton#closeBtn {"
+    "    background: transparent;"
+    "    color: #8badc4;"
+    "    border: none;"
+    "    border-radius: 4px;"
+    "    min-width: 28px;"
+    "    max-width: 28px;"
+    "    min-height: 24px;"
+    "    max-height: 24px;"
+    "    font-size: 13px;"
+    "    padding: 0px;"
+    "    margin-right: 4px;"
+    "}"
+    "QPushButton#closeBtn:hover {"
+    "    background: #ef4444;"
+    "    color: #ffffff;"
+    "}"
+    "QPushButton#closeBtn:pressed {"
+    "    background: #b91c1c;"
+    "    color: #ffffff;"
+    "}"
+
+    // --- Dock slot frames ---
+    "QFrame#slot {"
+    "    background: #0a1221;"
+    "    border: 1px solid #1e3350;"
+    "    border-radius: 10px;"
+    "    padding: 0px;"
+    "}"
+
+    // --- Slot zone label (LEFT / CENTER / RIGHT) ---
+    "QLabel#slotZoneLabel {"
+    "    color: #2a4a6e;"
+    "    font-size: 9px;"
+    "    font-weight: 600;"
+    "    letter-spacing: 3px;"
+    "    padding: 0px 0px 0px 2px;"
+    "}"
+
+    // --- Tab bar ---
+    "QTabBar {"
+    "    background: transparent;"
+    "    border: none;"
+    "    border-bottom: 1px solid #1e3350;"
+    "}"
+    "QTabBar::tab {"
+    "    background: transparent;"
+    "    color: #4d6d87;"
+    "    border: none;"
+    "    border-bottom: 2px solid transparent;"
+    "    padding: 7px 16px 6px 16px;"
+    "    font-size: 11px;"
+    "    font-weight: 500;"
+    "    letter-spacing: 0.5px;"
+    "    min-width: 60px;"
+    "}"
+    "QTabBar::tab:hover {"
+    "    color: #8badc4;"
+    "    border-bottom: 2px solid #2a4a6e;"
+    "}"
+    "QTabBar::tab:selected {"
+    "    color: #e0ecf7;"
+    "    border-bottom: 2px solid #3b82f6;"
+    "    font-weight: 600;"
+    "}"
+    "QTabBar::tab:!enabled {"
+    "    color: #2a4a6e;"
+    "}"
+
+    // --- Generic QPushButton (move buttons etc.) ---
+    "QPushButton {"
+    "    background: #0f1a2e;"
+    "    color: #8badc4;"
+    "    border: 1px solid #1e3350;"
+    "    border-radius: 6px;"
+    "    padding: 3px 10px;"
+    "    font-size: 11px;"
+    "}"
+    "QPushButton:hover {"
+    "    background: #162238;"
+    "    color: #e0ecf7;"
+    "    border-color: #2a4a6e;"
+    "}"
+    "QPushButton:pressed {"
+    "    background: #1e3350;"
+    "    color: #60a5fa;"
+    "    border-color: #3b82f6;"
+    "}"
+    "QPushButton:disabled {"
+    "    background: #060b14;"
+    "    color: #2a4a6e;"
+    "    border-color: #1e3350;"
+    "}"
+
+    // --- Panel move pill buttons ---
+    "QPushButton#moveBtn {"
+    "    background: #0f1a2e;"
+    "    color: #4d6d87;"
+    "    border: 1px solid #1e3350;"
+    "    border-radius: 10px;"
+    "    padding: 2px 9px;"
+    "    font-size: 10px;"
+    "    font-weight: 600;"
+    "    min-width: 22px;"
+    "    max-height: 20px;"
+    "}"
+    "QPushButton#moveBtn:hover {"
+    "    background: #162238;"
+    "    color: #60a5fa;"
+    "    border-color: #3b82f6;"
+    "}"
+    "QPushButton#moveBtn:disabled {"
+    "    background: #060b14;"
+    "    color: #1e3350;"
+    "    border-color: #0f1a2e;"
+    "}"
+
+    // --- Panel header separator line ---
+    "QFrame#panelHeaderLine {"
+    "    background: qlineargradient("
+    "        x1:0, y1:0, x2:1, y2:0,"
+    "        stop:0 #3b82f6,"
+    "        stop:0.4 #1e3350,"
+    "        stop:1 transparent"
+    "    );"
+    "    min-height: 1px;"
+    "    max-height: 1px;"
+    "    border: none;"
+    "}"
+
+    // --- Panel title label ---
+    "QLabel#panelTitle {"
+    "    color: #e0ecf7;"
+    "    font-size: 12px;"
+    "    font-weight: 600;"
+    "    letter-spacing: 1px;"
+    "}"
+
+    // --- "Move to:" prompt label ---
+    "QLabel#moveToLabel {"
+    "    color: #4d6d87;"
+    "    font-size: 9px;"
+    "    letter-spacing: 1px;"
+    "}"
+
+    // --- Telemetry metric labels ---
+    "QLabel#metricValue {"
+    "    color: #e0ecf7;"
+    "    font-size: 20px;"
+    "    font-weight: 700;"
+    "    letter-spacing: -0.5px;"
+    "}"
+    "QLabel#metricKey {"
+    "    color: #4d6d87;"
+    "    font-size: 9px;"
+    "    font-weight: 600;"
+    "    letter-spacing: 2px;"
+    "}"
+    "QLabel#metricUnit {"
+    "    color: #3b82f6;"
+    "    font-size: 12px;"
+    "    font-weight: 600;"
+    "}"
+
+    // --- Telemetry timestamp ---
+    "QLabel#telemetryTimestamp {"
+    "    color: #4d6d87;"
+    "    font-size: 10px;"
+    "}"
+
+    // --- Telemetry status ---
+    "QLabel#telemetryStatus {"
+    "    color: #8badc4;"
+    "    font-size: 10px;"
+    "    font-style: italic;"
+    "}"
+
+    // --- Process panel status label ---
+    "QLabel#processStatus {"
+    "    color: #4d6d87;"
+    "    font-size: 10px;"
+    "    font-style: italic;"
+    "    padding-bottom: 4px;"
+    "}"
+
+    // --- Process row labels (monospace) ---
+    "QLabel#processRow {"
+    "    color: #8badc4;"
+    "    font-family: 'Cascadia Mono', 'Consolas', monospace;"
+    "    font-size: 10px;"
+    "    padding: 3px 6px;"
+    "    border-radius: 3px;"
+    "}"
+    "QLabel#processRowAlt {"
+    "    color: #8badc4;"
+    "    font-family: 'Cascadia Mono', 'Consolas', monospace;"
+    "    font-size: 10px;"
+    "    background: #0a1221;"
+    "    padding: 3px 6px;"
+    "    border-radius: 3px;"
+    "}"
+
+    // --- Timeline and render status labels ---
+    "QLabel#timelineStatus {"
+    "    color: #4d6d87;"
+    "    font-size: 10px;"
+    "    font-style: italic;"
+    "}"
+    "QLabel#renderStatus {"
+    "    color: #4d6d87;"
+    "    font-size: 10px;"
+    "    font-style: italic;"
+    "}"
+
+    // --- Footer status bar ---
+    "QLabel#footerStatus {"
+    "    color: #2a4a6e;"
+    "    font-size: 9px;"
+    "    font-family: 'Cascadia Mono', 'Consolas', monospace;"
+    "    padding: 4px 12px 8px 14px;"
+    "    border-left: 2px solid #3b82f6;"
+    "    margin-left: 12px;"
+    "    margin-bottom: 4px;"
+    "}"
+
+    // --- Thin scrollbars ---
+    "QScrollBar:vertical {"
+    "    background: #060b14;"
+    "    width: 6px;"
+    "    border-radius: 3px;"
+    "    margin: 0px;"
+    "}"
+    "QScrollBar::handle:vertical {"
+    "    background: #1e3350;"
+    "    border-radius: 3px;"
+    "    min-height: 20px;"
+    "}"
+    "QScrollBar::handle:vertical:hover {"
+    "    background: #2a4a6e;"
+    "}"
+    "QScrollBar::add-line:vertical, QScrollBar::sub-line:vertical {"
+    "    height: 0px;"
+    "}"
+    "QScrollBar:horizontal {"
+    "    background: #060b14;"
+    "    height: 6px;"
+    "    border-radius: 3px;"
+    "    margin: 0px;"
+    "}"
+    "QScrollBar::handle:horizontal {"
+    "    background: #1e3350;"
+    "    border-radius: 3px;"
+    "    min-width: 20px;"
+    "}"
+    "QScrollBar::handle:horizontal:hover {"
+    "    background: #2a4a6e;"
+    "}"
+    "QScrollBar::add-line:horizontal, QScrollBar::sub-line:horizontal {"
+    "    width: 0px;"
+    "}"
+);
+
+// ---------------------------------------------------------------------------
+// AuraShellWindow
+// ---------------------------------------------------------------------------
+
 class AuraShellWindow final : public QMainWindow {
 public:
     explicit AuraShellWindow(const LaunchConfig& config, QWidget* parent = nullptr)
@@ -169,13 +524,7 @@ public:
         setWindowTitle("Aura | Native Shell");
         setMinimumSize(1100, 640);
         setWindowFlags(Qt::FramelessWindowHint | Qt::Window | Qt::WindowMinMaxButtonsHint);
-        setStyleSheet(
-            "QMainWindow{background:#091523;color:#d8ebff;}"
-            "QFrame#titlebar{background:#0e2237;border-bottom:1px solid #2f5e8b;}"
-            "QFrame#slot{background:#10263d;border:1px solid #355d84;border-radius:8px;}"
-            "QPushButton{background:#143251;color:#d8ebff;border:1px solid #3e6f9c;border-radius:4px;padding:4px 8px;}"
-            "QLabel#status{color:#9cc7ea;}"
-        );
+        setStyleSheet(k_app_stylesheet);
 
         aura::shell::CockpitController::Config controller_config;
         controller_config.poll_interval_seconds = config.interval_seconds;
@@ -195,19 +544,50 @@ public:
         root_layout->setContentsMargins(0, 0, 0, 0);
         root_layout->setSpacing(0);
 
+        // ---------------------------------------------------------------
+        // Title bar
+        // ---------------------------------------------------------------
         titlebar_ = new QFrame(root);
         titlebar_->setObjectName("titlebar");
         titlebar_->installEventFilter(this);
 
         auto* title_layout = new QHBoxLayout(titlebar_);
-        title_layout->setContentsMargins(10, 4, 4, 4);
-        title_layout->setSpacing(6);
-        title_layout->addWidget(new QLabel("Aura Native Cockpit", titlebar_));
+        title_layout->setContentsMargins(12, 0, 6, 0);
+        title_layout->setSpacing(0);
+
+        // Logo / app name
+        auto* logo_label = new QLabel("\u25c8 AURA", titlebar_);
+        logo_label->setObjectName("appLogo");
+        title_layout->addWidget(logo_label);
+
+        // Subtitle
+        auto* subtitle_label = new QLabel("NATIVE COCKPIT", titlebar_);
+        subtitle_label->setObjectName("titleSubtitle");
+        title_layout->addWidget(subtitle_label);
+
         title_layout->addStretch(1);
 
-        auto* min_btn = new QPushButton("_", titlebar_);
-        auto* max_btn = new QPushButton("[]", titlebar_);
-        auto* close_btn = new QPushButton("X", titlebar_);
+        // Window-control buttons with Unicode glyphs
+        auto* min_btn = new QPushButton("\u2212", titlebar_);   // − (minus)
+        auto* max_btn = new QPushButton("\u25a1", titlebar_);   // □ (square)
+        auto* close_btn = new QPushButton("\u00d7", titlebar_); // × (times)
+
+        min_btn->setObjectName("minBtn");
+        max_btn->setObjectName("maxBtn");
+        close_btn->setObjectName("closeBtn");
+
+        min_btn->setToolTip("Minimize");
+        max_btn->setToolTip("Maximize / Restore");
+        close_btn->setToolTip("Close");
+
+        min_btn->setCursor(Qt::ArrowCursor);
+        max_btn->setCursor(Qt::ArrowCursor);
+        close_btn->setCursor(Qt::ArrowCursor);
+
+        min_btn->setFocusPolicy(Qt::NoFocus);
+        max_btn->setFocusPolicy(Qt::NoFocus);
+        close_btn->setFocusPolicy(Qt::NoFocus);
+
         connect(min_btn, &QPushButton::clicked, this, &QWidget::showMinimized);
         connect(max_btn, &QPushButton::clicked, this, [this]() {
             if (isMaximized()) {
@@ -217,14 +597,22 @@ public:
             }
         });
         connect(close_btn, &QPushButton::clicked, this, &QWidget::close);
+
         title_layout->addWidget(min_btn);
+        title_layout->addSpacing(2);
         title_layout->addWidget(max_btn);
+        title_layout->addSpacing(2);
         title_layout->addWidget(close_btn);
+
         root_layout->addWidget(titlebar_);
 
+        // ---------------------------------------------------------------
+        // Main body — three dock slots
+        // ---------------------------------------------------------------
         auto* body = new QWidget(root);
+        body->setAutoFillBackground(false);
         auto* body_layout = new QHBoxLayout(body);
-        body_layout->setContentsMargins(12, 12, 12, 12);
+        body_layout->setContentsMargins(12, 12, 12, 8);
         body_layout->setSpacing(10);
 
         for (const auto slot : aura::shell::all_dock_slots()) {
@@ -243,6 +631,9 @@ public:
         rebuild_dock_slots();
         root_layout->addWidget(body, 1);
 
+        // ---------------------------------------------------------------
+        // Footer status bar
+        // ---------------------------------------------------------------
         footer_status_ = new QLabel(
             QString("interval=%1  persist=%2  db=%3")
                 .arg(config.interval_seconds)
@@ -250,12 +641,15 @@ public:
                 .arg(config.db_path.value_or("<none>")),
             root
         );
-        footer_status_->setObjectName("status");
-        footer_status_->setContentsMargins(12, 0, 12, 12);
+        footer_status_->setObjectName("footerStatus");
+        footer_status_->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
         root_layout->addWidget(footer_status_);
 
         setCentralWidget(root);
 
+        // ---------------------------------------------------------------
+        // Refresh timer
+        // ---------------------------------------------------------------
         update_timer_ = new QTimer(this);
         update_timer_->setInterval(interval_to_milliseconds(config_.interval_seconds));
         connect(update_timer_, &QTimer::timeout, this, [this]() {
@@ -296,47 +690,71 @@ protected:
     }
 
 private:
+    // -----------------------------------------------------------------------
+    // build_slot  —  creates one of the three dock-slot frames
+    // -----------------------------------------------------------------------
     SlotWidgets build_slot(const aura::shell::DockSlot slot, QWidget* parent) {
         auto* frame = new QFrame(parent);
         frame->setObjectName("slot");
-        auto* layout = new QVBoxLayout(frame);
-        layout->setContentsMargins(10, 10, 10, 10);
-        layout->setSpacing(8);
 
-        auto* title_label = new QLabel(slot_title(slot), frame);
+        auto* layout = new QVBoxLayout(frame);
+        layout->setContentsMargins(0, 8, 0, 10);
+        layout->setSpacing(0);
+
+        // Tiny zone label (LEFT / CENTER / RIGHT) rendered as watermark text
+        auto* zone_label = new QLabel(slot_title(slot), frame);
+        zone_label->setObjectName("slotZoneLabel");
+        zone_label->setContentsMargins(12, 0, 0, 2);
+
+        // Tab bar sits flush below the zone label
         auto* tab_bar = new QTabBar(frame);
         tab_bar->setDocumentMode(true);
-        tab_bar->setExpanding(true);
+        tab_bar->setExpanding(false);
         tab_bar->setMovable(false);
         tab_bar->setUsesScrollButtons(true);
+        tab_bar->setDrawBase(false);
+        tab_bar->setContentsMargins(8, 0, 8, 0);
+
+        // Content stack — padded inside the frame
         auto* stack = new QStackedWidget(frame);
-        layout->addWidget(title_label);
+        stack->setContentsMargins(0, 0, 0, 0);
+
+        layout->addWidget(zone_label);
         layout->addWidget(tab_bar);
         layout->addWidget(stack, 1);
-        return {
-            frame,
-            tab_bar,
-            stack,
-        };
+
+        return {frame, tab_bar, stack};
     }
 
+    // -----------------------------------------------------------------------
+    // create_panel_page  —  builds a panel widget with premium header
+    // -----------------------------------------------------------------------
     QVBoxLayout* create_panel_page(const aura::shell::PanelId panel_id, const QString& title) {
         auto* page = new QWidget(this);
         panel_pages_[panel_index(panel_id)] = page;
 
         auto* page_layout = new QVBoxLayout(page);
-        page_layout->setContentsMargins(0, 0, 0, 0);
-        page_layout->setSpacing(8);
+        page_layout->setContentsMargins(12, 10, 12, 8);
+        page_layout->setSpacing(0);
 
+        // --- Header row ---
         auto* header_layout = new QHBoxLayout();
         header_layout->setContentsMargins(0, 0, 0, 0);
         header_layout->setSpacing(6);
-        header_layout->addWidget(new QLabel(title, page));
+
+        auto* title_label = new QLabel(title.toUpper(), page);
+        title_label->setObjectName("panelTitle");
+        header_layout->addWidget(title_label);
         header_layout->addStretch(1);
-        header_layout->addWidget(new QLabel("Move", page));
+
+        auto* move_to_label = new QLabel("MOVE:", page);
+        move_to_label->setObjectName("moveToLabel");
+        header_layout->addWidget(move_to_label);
 
         for (const auto slot : aura::shell::all_dock_slots()) {
             auto* move_button = new QPushButton(slot_short_label(slot), page);
+            move_button->setObjectName("moveBtn");
+            move_button->setFocusPolicy(Qt::NoFocus);
             connect(move_button, &QPushButton::clicked, this, [this, panel_id, slot]() {
                 move_panel_to_slot(panel_id, slot);
             });
@@ -345,68 +763,142 @@ private:
         }
 
         page_layout->addLayout(header_layout);
+        page_layout->addSpacing(6);
 
+        // Accent separator line below header
+        auto* sep_line = new QFrame(page);
+        sep_line->setObjectName("panelHeaderLine");
+        sep_line->setFrameShape(QFrame::HLine);
+        sep_line->setFixedHeight(1);
+        page_layout->addWidget(sep_line);
+        page_layout->addSpacing(10);
+
+        // Content area
         auto* content_layout = new QVBoxLayout();
         content_layout->setContentsMargins(0, 0, 0, 0);
-        content_layout->setSpacing(6);
+        content_layout->setSpacing(4);
         page_layout->addLayout(content_layout, 1);
+
         return content_layout;
     }
 
+    // -----------------------------------------------------------------------
+    // build_panel_pages  —  constructs the 4 panel content areas
+    // -----------------------------------------------------------------------
     void build_panel_pages() {
         using aura::shell::PanelId;
 
+        // --- Telemetry Overview ---
         {
             auto* telemetry_layout =
                 create_panel_page(PanelId::TelemetryOverview, QStringLiteral("Telemetry Overview"));
-            telemetry_cpu_ = new QLabel("CPU --", panel_pages_[panel_index(PanelId::TelemetryOverview)]);
-            telemetry_memory_ = new QLabel("Memory --", panel_pages_[panel_index(PanelId::TelemetryOverview)]);
-            telemetry_timestamp_ = new QLabel("Timestamp --", panel_pages_[panel_index(PanelId::TelemetryOverview)]);
-            telemetry_status_ =
-                new QLabel("Awaiting telemetry snapshot...", panel_pages_[panel_index(PanelId::TelemetryOverview)]);
-            telemetry_status_->setWordWrap(true);
 
-            telemetry_layout->addWidget(telemetry_cpu_);
-            telemetry_layout->addWidget(telemetry_memory_);
+            QWidget* parent_page = panel_pages_[panel_index(PanelId::TelemetryOverview)];
+
+            // CPU metric block
+            auto* cpu_block = new QWidget(parent_page);
+            auto* cpu_block_layout = new QVBoxLayout(cpu_block);
+            cpu_block_layout->setContentsMargins(0, 0, 0, 8);
+            cpu_block_layout->setSpacing(1);
+
+            auto* cpu_key = new QLabel("CPU LOAD", parent_page);
+            cpu_key->setObjectName("metricKey");
+            telemetry_cpu_ = new QLabel("CPU --", parent_page);
+            telemetry_cpu_->setObjectName("metricValue");
+
+            cpu_block_layout->addWidget(cpu_key);
+            cpu_block_layout->addWidget(telemetry_cpu_);
+            telemetry_layout->addWidget(cpu_block);
+
+            // Memory metric block
+            auto* mem_block = new QWidget(parent_page);
+            auto* mem_block_layout = new QVBoxLayout(mem_block);
+            mem_block_layout->setContentsMargins(0, 0, 0, 8);
+            mem_block_layout->setSpacing(1);
+
+            auto* mem_key = new QLabel("MEMORY USE", parent_page);
+            mem_key->setObjectName("metricKey");
+            telemetry_memory_ = new QLabel("Memory --", parent_page);
+            telemetry_memory_->setObjectName("metricValue");
+
+            mem_block_layout->addWidget(mem_key);
+            mem_block_layout->addWidget(telemetry_memory_);
+            telemetry_layout->addWidget(mem_block);
+
+            // Timestamp and status
+            telemetry_timestamp_ = new QLabel("Timestamp --", parent_page);
+            telemetry_timestamp_->setObjectName("telemetryTimestamp");
             telemetry_layout->addWidget(telemetry_timestamp_);
+
+            telemetry_status_ = new QLabel("Awaiting telemetry snapshot...", parent_page);
+            telemetry_status_->setObjectName("telemetryStatus");
+            telemetry_status_->setWordWrap(true);
             telemetry_layout->addWidget(telemetry_status_);
+
             telemetry_layout->addStretch(1);
         }
 
+        // --- Top Processes ---
         {
-            auto* processes_layout = create_panel_page(PanelId::TopProcesses, QStringLiteral("Top Processes"));
-            process_status_ = new QLabel("Waiting for process samples...", panel_pages_[panel_index(PanelId::TopProcesses)]);
+            auto* processes_layout =
+                create_panel_page(PanelId::TopProcesses, QStringLiteral("Top Processes"));
+
+            QWidget* parent_page = panel_pages_[panel_index(PanelId::TopProcesses)];
+
+            process_status_ = new QLabel("Waiting for process samples...", parent_page);
+            process_status_->setObjectName("processStatus");
             process_status_->setWordWrap(true);
             processes_layout->addWidget(process_status_);
-            for (QLabel*& process_label : process_labels_) {
-                process_label = new QLabel("-", panel_pages_[panel_index(PanelId::TopProcesses)]);
-                process_label->setTextInteractionFlags(Qt::TextSelectableByMouse);
-                processes_layout->addWidget(process_label);
+
+            for (std::size_t i = 0; i < process_labels_.size(); ++i) {
+                process_labels_[i] = new QLabel("-", parent_page);
+                // Alternate row styling for readability
+                process_labels_[i]->setObjectName((i % 2 == 0) ? "processRow" : "processRowAlt");
+                process_labels_[i]->setTextInteractionFlags(Qt::TextSelectableByMouse);
+                process_labels_[i]->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+                processes_layout->addWidget(process_labels_[i]);
             }
             processes_layout->addStretch(1);
         }
 
+        // --- DVR Timeline ---
         {
-            auto* timeline_layout = create_panel_page(PanelId::DvrTimeline, QStringLiteral("DVR Timeline"));
-            timeline_status_ = new QLabel("Awaiting timeline samples...", panel_pages_[panel_index(PanelId::DvrTimeline)]);
+            auto* timeline_layout =
+                create_panel_page(PanelId::DvrTimeline, QStringLiteral("DVR Timeline"));
+
+            QWidget* parent_page = panel_pages_[panel_index(PanelId::DvrTimeline)];
+
+            timeline_status_ = new QLabel("Awaiting timeline samples...", parent_page);
+            timeline_status_->setObjectName("timelineStatus");
             timeline_status_->setWordWrap(true);
             timeline_layout->addWidget(timeline_status_);
             timeline_layout->addStretch(1);
         }
 
+        // --- Render Surface ---
         {
-            auto* render_layout = create_panel_page(PanelId::RenderSurface, QStringLiteral("Render Surface"));
-            quick_ = new QQuickWidget(panel_pages_[panel_index(PanelId::RenderSurface)]);
+            auto* render_layout =
+                create_panel_page(PanelId::RenderSurface, QStringLiteral("Render Surface"));
+
+            QWidget* parent_page = panel_pages_[panel_index(PanelId::RenderSurface)];
+
+            quick_ = new QQuickWidget(parent_page);
             quick_->setResizeMode(QQuickWidget::SizeRootObjectToView);
             quick_->setSource(QUrl::fromLocalFile(QStringLiteral(AURA_SHELL_QML_PATH)));
             quick_->setMinimumHeight(340);
-            render_status_ = new QLabel("Cockpit scene online", panel_pages_[panel_index(PanelId::RenderSurface)]);
+
+            render_status_ = new QLabel("Cockpit scene online", parent_page);
+            render_status_->setObjectName("renderStatus");
             render_status_->setWordWrap(true);
+
             render_layout->addWidget(quick_, 1);
             render_layout->addWidget(render_status_);
         }
     }
 
+    // -----------------------------------------------------------------------
+    // Dock model helpers
+    // -----------------------------------------------------------------------
     std::optional<aura::shell::DockSlot> panel_slot(const aura::shell::PanelId panel_id) const {
         for (const auto slot : aura::shell::all_dock_slots()) {
             const auto& tabs = dock_state_.slot_tabs[slot_index(slot)];
@@ -421,32 +913,32 @@ private:
         syncing_tabs_ = true;
         for (const auto slot : aura::shell::all_dock_slots()) {
             const std::size_t slot_idx = slot_index(slot);
-            auto& slot_widgets = slot_widgets_[slot_idx];
+            auto& sw = slot_widgets_[slot_idx];
 
-            while (slot_widgets.tab_bar->count() > 0) {
-                slot_widgets.tab_bar->removeTab(0);
+            while (sw.tab_bar->count() > 0) {
+                sw.tab_bar->removeTab(0);
             }
-            while (slot_widgets.stack->count() > 0) {
-                slot_widgets.stack->removeWidget(slot_widgets.stack->widget(0));
+            while (sw.stack->count() > 0) {
+                sw.stack->removeWidget(sw.stack->widget(0));
             }
         }
 
         for (const auto slot : aura::shell::all_dock_slots()) {
             const std::size_t slot_idx = slot_index(slot);
-            auto& slot_widgets = slot_widgets_[slot_idx];
-
+            auto& sw = slot_widgets_[slot_idx];
             const auto& tabs = dock_state_.slot_tabs[slot_idx];
+
             for (const auto panel_id : tabs) {
-                slot_widgets.tab_bar->addTab(panel_title(panel_id));
+                sw.tab_bar->addTab(panel_title(panel_id));
                 QWidget* page = panel_pages_[panel_index(panel_id)];
                 if (page != nullptr) {
-                    slot_widgets.stack->addWidget(page);
+                    sw.stack->addWidget(page);
                 }
             }
 
             if (tabs.empty()) {
-                slot_widgets.tab_bar->setCurrentIndex(-1);
-                slot_widgets.stack->setCurrentIndex(-1);
+                sw.tab_bar->setCurrentIndex(-1);
+                sw.stack->setCurrentIndex(-1);
                 continue;
             }
 
@@ -454,8 +946,8 @@ private:
                 dock_state_.active_tab[slot_idx],
                 tabs.size() - 1U
             ));
-            slot_widgets.tab_bar->setCurrentIndex(active_tab);
-            slot_widgets.stack->setCurrentIndex(active_tab);
+            sw.tab_bar->setCurrentIndex(active_tab);
+            sw.stack->setCurrentIndex(active_tab);
         }
         syncing_tabs_ = false;
         update_move_button_states();
@@ -517,11 +1009,15 @@ private:
         }
     }
 
+    // -----------------------------------------------------------------------
+    // refresh_cockpit  —  propagate CockpitController state to all widgets
+    // -----------------------------------------------------------------------
     void refresh_cockpit() {
         if (!controller_) {
             return;
         }
         const auto state = controller_->tick(config_.interval_seconds);
+
         telemetry_cpu_->setText(QString::fromStdString(state.cpu_line));
         telemetry_memory_->setText(QString::fromStdString(state.memory_line));
         telemetry_timestamp_->setText(QString::fromStdString(state.timestamp_line));
@@ -537,6 +1033,7 @@ private:
             process_labels_[i]->setText(line);
         }
 
+        // Footer — compact status summary
         QString footer_text =
             QString("interval=%1  persist=%2  db=%3  telemetry=%4  render=%5  timeline=%6  style=%7")
                 .arg(config_.interval_seconds)
@@ -555,6 +1052,7 @@ private:
         }
         footer_status_->setText(footer_text);
 
+        // QML property bridge — property names unchanged
         if (quick_ != nullptr && quick_->rootObject() != nullptr) {
             QQuickItem* root = quick_->rootObject();
             root->setProperty("accentIntensity", state.accent_intensity);
@@ -574,6 +1072,9 @@ private:
         }
     }
 
+    // -----------------------------------------------------------------------
+    // Member data
+    // -----------------------------------------------------------------------
     LaunchConfig config_{};
     std::unique_ptr<aura::shell::CockpitController> controller_;
     aura::shell::DockState dock_state_{aura::shell::build_default_dock_state()};
@@ -601,6 +1102,8 @@ private:
 
 int main(int argc, char* argv[]) {
     QApplication app(argc, argv);
+    app.setApplicationName("Aura");
+    app.setApplicationVersion("1.0.0");
     const LaunchConfig config = parse_args(app);
     AuraShellWindow window(config);
     window.show();

--- a/tests/test_shell/CMakeLists.txt
+++ b/tests/test_shell/CMakeLists.txt
@@ -1,3 +1,15 @@
+cmake_minimum_required(VERSION 3.26)
+project(aura_shell_tests LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+set(AURA_SHELL_BUILD_APP OFF CACHE BOOL "" FORCE)
+add_subdirectory(../../src/shell/native ${CMAKE_BINARY_DIR}/shell-native)
+
+enable_testing()
+
 add_executable(aura_shell_dock_model_tests
     native/dock_model_tests.cpp
 )

--- a/tests/test_shell/native/dock_model_tests.cpp
+++ b/tests/test_shell/native/dock_model_tests.cpp
@@ -4,6 +4,7 @@
 #include <cstddef>
 #include <optional>
 #include <stdexcept>
+#include <string_view>
 
 namespace {
 
@@ -156,14 +157,530 @@ void test_empty_slot_behavior() {
     assert(threw);
 }
 
+// ---------------------------------------------------------------------------
+// NEW: All panels moved to a single slot
+// ---------------------------------------------------------------------------
+
+// Move all 4 panels to Left. Left should contain exactly 4 panels.
+// Center and Right must be empty. active_panel for each must resolve correctly.
+void test_all_panels_to_single_slot() {
+    using aura::shell::DockSlot;
+    using aura::shell::PanelId;
+    using aura::shell::PanelMoveRequest;
+
+    auto state = aura::shell::build_default_dock_state();
+
+    // Default has: Left={TelemetryOverview}, Center={TopProcesses, DvrTimeline}, Right={RenderSurface}
+    // Move TopProcesses -> Left
+    state = aura::shell::move_panel(
+        state,
+        PanelMoveRequest{
+            .panel_id = PanelId::TopProcesses,
+            .to_slot = DockSlot::Left,
+            .to_index = std::nullopt,
+        }
+    );
+    // Move DvrTimeline -> Left
+    state = aura::shell::move_panel(
+        state,
+        PanelMoveRequest{
+            .panel_id = PanelId::DvrTimeline,
+            .to_slot = DockSlot::Left,
+            .to_index = std::nullopt,
+        }
+    );
+    // Move RenderSurface -> Left
+    state = aura::shell::move_panel(
+        state,
+        PanelMoveRequest{
+            .panel_id = PanelId::RenderSurface,
+            .to_slot = DockSlot::Left,
+            .to_index = std::nullopt,
+        }
+    );
+
+    // All 4 panels must be in Left
+    assert(state.slot_tabs[slot_index(DockSlot::Left)].size() == 4U);
+
+    // Center and Right must be empty
+    assert(state.slot_tabs[slot_index(DockSlot::Center)].empty());
+    assert(state.slot_tabs[slot_index(DockSlot::Right)].empty());
+
+    // active_panel for Center/Right returns nullopt
+    assert(!aura::shell::active_panel(state, DockSlot::Center).has_value());
+    assert(!aura::shell::active_panel(state, DockSlot::Right).has_value());
+
+    // active_panel for Left returns the panel at active_tab[Left]
+    const auto left_active = aura::shell::active_panel(state, DockSlot::Left);
+    assert(left_active.has_value());
+
+    // Uniqueness invariant still holds
+    assert_single_instance_per_panel(state);
+
+    // Each panel must appear exactly once across all slots
+    for (const auto panel_id : aura::shell::all_panel_ids()) {
+        assert(panel_count(state, panel_id) == 1U);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// NEW: Moving a panel to its current slot is a no-op (same slot, no to_index)
+// ---------------------------------------------------------------------------
+
+// Move TelemetryOverview to Left (where it already is with no to_index).
+// The state should be functionally identical: same panel count, same active_panel.
+void test_move_same_slot_is_noop() {
+    using aura::shell::DockSlot;
+    using aura::shell::PanelId;
+    using aura::shell::PanelMoveRequest;
+
+    const auto original = aura::shell::build_default_dock_state();
+
+    // TelemetryOverview starts in Left. Move it back to Left (no explicit index).
+    const auto after_move = aura::shell::move_panel(
+        original,
+        PanelMoveRequest{
+            .panel_id = PanelId::TelemetryOverview,
+            .to_slot = DockSlot::Left,
+            .to_index = std::nullopt,
+        }
+    );
+
+    // Both before and after: Left has exactly 1 panel (TelemetryOverview)
+    assert(after_move.slot_tabs[slot_index(DockSlot::Left)].size() == 1U);
+    assert(after_move.slot_tabs[slot_index(DockSlot::Left)][0] == PanelId::TelemetryOverview);
+
+    // Center and Right are unchanged
+    assert(
+        after_move.slot_tabs[slot_index(DockSlot::Center)].size() ==
+        original.slot_tabs[slot_index(DockSlot::Center)].size()
+    );
+    assert(
+        after_move.slot_tabs[slot_index(DockSlot::Right)].size() ==
+        original.slot_tabs[slot_index(DockSlot::Right)].size()
+    );
+
+    // Active panel for Left is still TelemetryOverview
+    const auto left_panel = aura::shell::active_panel(after_move, DockSlot::Left);
+    assert(left_panel.has_value());
+    assert(*left_panel == PanelId::TelemetryOverview);
+
+    // Uniqueness preserved
+    assert_single_instance_per_panel(after_move);
+}
+
+// ---------------------------------------------------------------------------
+// NEW: Active tab round-trips through moves and re-assignments
+// ---------------------------------------------------------------------------
+
+// Set active tab for each slot, then perform unrelated moves,
+// and verify active tabs survive or clamp correctly.
+void test_active_tab_round_trips() {
+    using aura::shell::DockSlot;
+    using aura::shell::PanelId;
+    using aura::shell::PanelMoveRequest;
+
+    // Default: Left={TelemetryOverview[0]}, Center={TopProcesses[0], DvrTimeline[1]}, Right={RenderSurface[0]}
+    auto state = aura::shell::build_default_dock_state();
+
+    // Set Center active tab to 1 (DvrTimeline)
+    state = aura::shell::set_active_tab(state, DockSlot::Center, 1U);
+    assert(state.active_tab[slot_index(DockSlot::Center)] == 1U);
+
+    // Confirm active_panel reflects DvrTimeline
+    {
+        const auto panel = aura::shell::active_panel(state, DockSlot::Center);
+        assert(panel.has_value());
+        assert(*panel == PanelId::DvrTimeline);
+    }
+
+    // Move RenderSurface from Right to Right at explicit index 0 (stays there)
+    state = aura::shell::move_panel(
+        state,
+        PanelMoveRequest{
+            .panel_id = PanelId::RenderSurface,
+            .to_slot = DockSlot::Right,
+            .to_index = 0U,
+        }
+    );
+
+    // Center active tab should still resolve to DvrTimeline (unchanged by this move)
+    {
+        const auto panel = aura::shell::active_panel(state, DockSlot::Center);
+        assert(panel.has_value());
+        assert(*panel == PanelId::DvrTimeline);
+    }
+
+    // Right active_tab was updated to 0 (insertion at 0); RenderSurface should still be active
+    {
+        const auto right_panel = aura::shell::active_panel(state, DockSlot::Right);
+        assert(right_panel.has_value());
+        assert(*right_panel == PanelId::RenderSurface);
+    }
+
+    // Reset: move Center active to 0
+    state = aura::shell::set_active_tab(state, DockSlot::Center, 0U);
+    assert(state.active_tab[slot_index(DockSlot::Center)] == 0U);
+    {
+        const auto panel = aura::shell::active_panel(state, DockSlot::Center);
+        assert(panel.has_value());
+        assert(*panel == PanelId::TopProcesses);
+    }
+
+    // Uniqueness invariant
+    assert_single_instance_per_panel(state);
+}
+
+// ---------------------------------------------------------------------------
+// NEW: Panel ordering after a sequence of targeted index moves
+// ---------------------------------------------------------------------------
+
+// Build a specific tab order by inserting panels at explicit indices and
+// verify that the resulting order matches expectations exactly.
+void test_panel_ordering_after_moves() {
+    using aura::shell::DockSlot;
+    using aura::shell::PanelId;
+    using aura::shell::PanelMoveRequest;
+
+    // Start fresh
+    auto state = aura::shell::build_default_dock_state();
+    // Default: Left={TelemetryOverview}, Center={TopProcesses, DvrTimeline}, Right={RenderSurface}
+
+    // Move RenderSurface from Right to Center at index 0
+    // Center becomes: {RenderSurface, TopProcesses, DvrTimeline}
+    state = aura::shell::move_panel(
+        state,
+        PanelMoveRequest{
+            .panel_id = PanelId::RenderSurface,
+            .to_slot = DockSlot::Center,
+            .to_index = 0U,
+        }
+    );
+    assert(state.slot_tabs[slot_index(DockSlot::Center)].size() == 3U);
+    assert(state.slot_tabs[slot_index(DockSlot::Center)][0] == PanelId::RenderSurface);
+    assert(state.slot_tabs[slot_index(DockSlot::Center)][1] == PanelId::TopProcesses);
+    assert(state.slot_tabs[slot_index(DockSlot::Center)][2] == PanelId::DvrTimeline);
+
+    // Right is now empty
+    assert(state.slot_tabs[slot_index(DockSlot::Right)].empty());
+
+    // Move TelemetryOverview from Left to Center at index 1
+    // Center becomes: {RenderSurface, TelemetryOverview, TopProcesses, DvrTimeline}
+    state = aura::shell::move_panel(
+        state,
+        PanelMoveRequest{
+            .panel_id = PanelId::TelemetryOverview,
+            .to_slot = DockSlot::Center,
+            .to_index = 1U,
+        }
+    );
+    assert(state.slot_tabs[slot_index(DockSlot::Center)].size() == 4U);
+    assert(state.slot_tabs[slot_index(DockSlot::Center)][0] == PanelId::RenderSurface);
+    assert(state.slot_tabs[slot_index(DockSlot::Center)][1] == PanelId::TelemetryOverview);
+    assert(state.slot_tabs[slot_index(DockSlot::Center)][2] == PanelId::TopProcesses);
+    assert(state.slot_tabs[slot_index(DockSlot::Center)][3] == PanelId::DvrTimeline);
+
+    // Left and Right are both empty
+    assert(state.slot_tabs[slot_index(DockSlot::Left)].empty());
+    assert(state.slot_tabs[slot_index(DockSlot::Right)].empty());
+
+    // Confirm active_panel for Center points to the panel at active_tab[Center]
+    {
+        const std::size_t active = state.active_tab[slot_index(DockSlot::Center)];
+        assert(active < state.slot_tabs[slot_index(DockSlot::Center)].size());
+        const auto active_p = aura::shell::active_panel(state, DockSlot::Center);
+        assert(active_p.has_value());
+        assert(*active_p == state.slot_tabs[slot_index(DockSlot::Center)][active]);
+    }
+
+    // Uniqueness invariant
+    assert_single_instance_per_panel(state);
+}
+
+// ---------------------------------------------------------------------------
+// NEW: to_string round-trip for all slots and all panels
+// ---------------------------------------------------------------------------
+
+void test_to_string_all_slots_and_panels() {
+    using aura::shell::DockSlot;
+    using aura::shell::PanelId;
+
+    // Verify to_string returns non-empty, non-"unknown" for all valid values
+    assert(aura::shell::to_string(DockSlot::Left)   == "left");
+    assert(aura::shell::to_string(DockSlot::Center) == "center");
+    assert(aura::shell::to_string(DockSlot::Right)  == "right");
+
+    assert(aura::shell::to_string(PanelId::TelemetryOverview) == "telemetry_overview");
+    assert(aura::shell::to_string(PanelId::TopProcesses)      == "top_processes");
+    assert(aura::shell::to_string(PanelId::DvrTimeline)       == "dvr_timeline");
+    assert(aura::shell::to_string(PanelId::RenderSurface)     == "render_surface");
+
+    // None of the string representations should be "unknown"
+    assert(aura::shell::to_string(DockSlot::Left)   != "unknown");
+    assert(aura::shell::to_string(DockSlot::Center) != "unknown");
+    assert(aura::shell::to_string(DockSlot::Right)  != "unknown");
+    assert(aura::shell::to_string(PanelId::TelemetryOverview) != "unknown");
+    assert(aura::shell::to_string(PanelId::TopProcesses)      != "unknown");
+    assert(aura::shell::to_string(PanelId::DvrTimeline)       != "unknown");
+    assert(aura::shell::to_string(PanelId::RenderSurface)     != "unknown");
+}
+
+// ---------------------------------------------------------------------------
+// NEW: all_panel_ids() and all_dock_slots() coverage and ordering
+// ---------------------------------------------------------------------------
+
+void test_all_panel_ids_and_slots_counts() {
+    const auto panels = aura::shell::all_panel_ids();
+    assert(panels.size() == 4U);
+
+    const auto slots = aura::shell::all_dock_slots();
+    assert(slots.size() == 3U);
+
+    // Verify all expected panels are present
+    bool found_telemetry = false;
+    bool found_processes = false;
+    bool found_dvr = false;
+    bool found_render = false;
+    for (const auto panel_id : panels) {
+        if (panel_id == aura::shell::PanelId::TelemetryOverview) { found_telemetry = true; }
+        if (panel_id == aura::shell::PanelId::TopProcesses)      { found_processes = true; }
+        if (panel_id == aura::shell::PanelId::DvrTimeline)       { found_dvr = true; }
+        if (panel_id == aura::shell::PanelId::RenderSurface)     { found_render = true; }
+    }
+    assert(found_telemetry);
+    assert(found_processes);
+    assert(found_dvr);
+    assert(found_render);
+
+    // Verify all expected slots are present
+    bool found_left = false;
+    bool found_center = false;
+    bool found_right = false;
+    for (const auto slot : slots) {
+        if (slot == aura::shell::DockSlot::Left)   { found_left = true; }
+        if (slot == aura::shell::DockSlot::Center) { found_center = true; }
+        if (slot == aura::shell::DockSlot::Right)  { found_right = true; }
+    }
+    assert(found_left);
+    assert(found_center);
+    assert(found_right);
+}
+
+// ---------------------------------------------------------------------------
+// NEW: Default state initial active_tabs are all zero
+// ---------------------------------------------------------------------------
+
+void test_default_state_active_tabs_are_zero() {
+    const auto state = aura::shell::build_default_dock_state();
+    for (const auto slot : aura::shell::all_dock_slots()) {
+        assert(state.active_tab[slot_index(slot)] == 0U);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// NEW: Move to out-of-range to_index throws
+// ---------------------------------------------------------------------------
+
+void test_move_out_of_range_index_throws() {
+    using aura::shell::DockSlot;
+    using aura::shell::PanelId;
+    using aura::shell::PanelMoveRequest;
+
+    const auto state = aura::shell::build_default_dock_state();
+    // Center has 2 panels (TopProcesses, DvrTimeline).
+    // Valid to_index values are 0, 1, 2 (append). Index 3 is out of range.
+    bool threw = false;
+    try {
+        static_cast<void>(aura::shell::move_panel(
+            state,
+            PanelMoveRequest{
+                .panel_id = PanelId::TelemetryOverview,
+                .to_slot = DockSlot::Center,
+                .to_index = 10U,  // Far out of range
+            }
+        ));
+    } catch (const std::invalid_argument&) {
+        threw = true;
+    }
+    assert(threw);
+}
+
+// ---------------------------------------------------------------------------
+// NEW: set_active_tab with tab_index=0 on empty slot is allowed
+// ---------------------------------------------------------------------------
+
+void test_set_active_tab_zero_on_empty_slot_allowed() {
+    using aura::shell::DockSlot;
+    using aura::shell::PanelId;
+    using aura::shell::PanelMoveRequest;
+
+    // Create a state where Right has no panels
+    const auto state = aura::shell::build_default_dock_state();
+    const auto empty_state = aura::shell::move_panel(
+        state,
+        PanelMoveRequest{
+            .panel_id = PanelId::RenderSurface,
+            .to_slot = DockSlot::Center,
+            .to_index = std::nullopt,
+        }
+    );
+    assert(empty_state.slot_tabs[slot_index(DockSlot::Right)].empty());
+
+    // Setting active_tab=0 on an empty slot must not throw
+    bool threw = false;
+    try {
+        static_cast<void>(aura::shell::set_active_tab(empty_state, DockSlot::Right, 0U));
+    } catch (...) {
+        threw = true;
+    }
+    assert(!threw);
+
+    // active_panel on empty slot should return nullopt
+    assert(!aura::shell::active_panel(empty_state, DockSlot::Right).has_value());
+}
+
+// ---------------------------------------------------------------------------
+// NEW: Append semantics: move with nullopt to_index appends to end
+// ---------------------------------------------------------------------------
+
+void test_move_nullopt_index_appends_to_end() {
+    using aura::shell::DockSlot;
+    using aura::shell::PanelId;
+    using aura::shell::PanelMoveRequest;
+
+    // Default: Center={TopProcesses[0], DvrTimeline[1]}
+    const auto state = aura::shell::build_default_dock_state();
+
+    // Move TelemetryOverview to Center with nullopt → should be appended at index 2
+    const auto moved = aura::shell::move_panel(
+        state,
+        PanelMoveRequest{
+            .panel_id = PanelId::TelemetryOverview,
+            .to_slot = DockSlot::Center,
+            .to_index = std::nullopt,
+        }
+    );
+
+    // Center now has 3 panels: {TopProcesses, DvrTimeline, TelemetryOverview}
+    assert(moved.slot_tabs[slot_index(DockSlot::Center)].size() == 3U);
+    assert(moved.slot_tabs[slot_index(DockSlot::Center)][0] == PanelId::TopProcesses);
+    assert(moved.slot_tabs[slot_index(DockSlot::Center)][1] == PanelId::DvrTimeline);
+    assert(moved.slot_tabs[slot_index(DockSlot::Center)][2] == PanelId::TelemetryOverview);
+
+    // Destination active_tab should point to the newly inserted panel at index 2
+    assert(moved.active_tab[slot_index(DockSlot::Center)] == 2U);
+    const auto center_active = aura::shell::active_panel(moved, DockSlot::Center);
+    assert(center_active.has_value());
+    assert(*center_active == PanelId::TelemetryOverview);
+
+    // Left is now empty
+    assert(moved.slot_tabs[slot_index(DockSlot::Left)].empty());
+
+    assert_single_instance_per_panel(moved);
+}
+
+// ---------------------------------------------------------------------------
+// NEW: Full shuffle: move every panel to a different slot
+// ---------------------------------------------------------------------------
+
+// Perform a complete 4-move shuffle so every panel ends up in a different slot
+// than it started in, and verify the invariant at every step.
+void test_full_panel_shuffle_preserves_uniqueness() {
+    using aura::shell::DockSlot;
+    using aura::shell::PanelId;
+    using aura::shell::PanelMoveRequest;
+
+    // Default:
+    //   Left = { TelemetryOverview }
+    //   Center = { TopProcesses, DvrTimeline }
+    //   Right = { RenderSurface }
+
+    auto state = aura::shell::build_default_dock_state();
+    assert_single_instance_per_panel(state);
+
+    // Step 1: TelemetryOverview -> Right
+    state = aura::shell::move_panel(
+        state, PanelMoveRequest{PanelId::TelemetryOverview, DockSlot::Right, std::nullopt}
+    );
+    assert_single_instance_per_panel(state);
+
+    // Step 2: RenderSurface -> Left
+    state = aura::shell::move_panel(
+        state, PanelMoveRequest{PanelId::RenderSurface, DockSlot::Left, std::nullopt}
+    );
+    assert_single_instance_per_panel(state);
+
+    // Step 3: TopProcesses -> Right
+    state = aura::shell::move_panel(
+        state, PanelMoveRequest{PanelId::TopProcesses, DockSlot::Right, std::nullopt}
+    );
+    assert_single_instance_per_panel(state);
+
+    // Step 4: DvrTimeline -> Left
+    state = aura::shell::move_panel(
+        state, PanelMoveRequest{PanelId::DvrTimeline, DockSlot::Left, std::nullopt}
+    );
+    assert_single_instance_per_panel(state);
+
+    // End state:
+    //   Left = { RenderSurface, DvrTimeline }
+    //   Center = {} (empty)
+    //   Right = { TelemetryOverview, TopProcesses }
+    assert(state.slot_tabs[slot_index(DockSlot::Left)].size() == 2U);
+    assert(state.slot_tabs[slot_index(DockSlot::Center)].empty());
+    assert(state.slot_tabs[slot_index(DockSlot::Right)].size() == 2U);
+
+    // Left[0] == RenderSurface (moved there first)
+    assert(state.slot_tabs[slot_index(DockSlot::Left)][0] == PanelId::RenderSurface);
+    assert(state.slot_tabs[slot_index(DockSlot::Left)][1] == PanelId::DvrTimeline);
+
+    // Right[0] == TelemetryOverview (moved there first)
+    assert(state.slot_tabs[slot_index(DockSlot::Right)][0] == PanelId::TelemetryOverview);
+    assert(state.slot_tabs[slot_index(DockSlot::Right)][1] == PanelId::TopProcesses);
+
+    // active_panel for Center must be nullopt
+    assert(!aura::shell::active_panel(state, DockSlot::Center).has_value());
+}
+
 }  // namespace
 
 int main() {
+    // --- Existing tests (unchanged) ---
     test_default_layout();
     test_repeated_moves_preserve_uniqueness();
     test_active_tab_clamps_after_panel_removal();
     test_destination_active_tab_tracks_inserted_panel();
     test_set_active_tab_out_of_range_throws();
     test_empty_slot_behavior();
+
+    // --- New: Aggregate slot tests ---
+    test_all_panels_to_single_slot();
+    test_move_same_slot_is_noop();
+
+    // --- New: Active tab round-trips ---
+    test_active_tab_round_trips();
+
+    // --- New: Panel ordering ---
+    test_panel_ordering_after_moves();
+
+    // --- New: to_string coverage ---
+    test_to_string_all_slots_and_panels();
+
+    // --- New: all_panel_ids / all_dock_slots ---
+    test_all_panel_ids_and_slots_counts();
+
+    // --- New: Default state invariants ---
+    test_default_state_active_tabs_are_zero();
+
+    // --- New: Error path coverage ---
+    test_move_out_of_range_index_throws();
+    test_set_active_tab_zero_on_empty_slot_allowed();
+
+    // --- New: Append semantics ---
+    test_move_nullopt_index_appends_to_end();
+
+    // --- New: Full shuffle invariant ---
+    test_full_panel_shuffle_preserves_uniqueness();
+
     return 0;
 }


### PR DESCRIPTION
## Summary

Complete visual redesign of the Aura cockpit — from 90s debug UI to premium cinematic system monitor.

### QML Cockpit Scene (780 lines, rewritten from scratch)
- **Arc gauges**: Canvas-rendered 270° sweep with gradient color interpolation (blue→cyan→amber→red by load), animated sweep transitions, outer glow halos, tick notches at 25/50/75%, leading dot pointer
- **Sparkline charts**: JS-buffered history (120 samples), quadratic bezier curve smoothing, gradient-filled area with crisp line overlay, separate color channels for CPU vs memory
- **Glassmorphism**: Layered background (gradient base → vignette → frosted surface → accent border → highlight edge → glow pulse), all driven by style tokens
- **Typography**: 5-level hierarchy (title/gauge value/gauge label/sparkline/status), all responsive sizing
- **Animations**: Smooth easing on all transitions (600ms arc sweep, 400ms color, 180ms accent), pulsing status dot heartbeat

### Qt Widgets Shell (main.cpp, 629 lines added)
- **Stylesheet**: 325-line comprehensive dark theme — 4 depth levels, modern tab bar with bottom indicators, pill-shaped move buttons, hover states throughout
- **Title bar**: "◈ AURA" logo in accent blue, Unicode window controls (−/□/×), red close-on-hover
- **Panel headers**: Uppercase titles with accent separator lines
- **Process list**: Monospace font (Cascadia Mono/Consolas), alternating row backgrounds
- **Footer**: 9px monospace, muted with 2px left accent border
- **Telemetry panel**: Key/value layout with 20px bold metric readouts

### Render Module (theme + widget models)
- **AuraPalette**: 20 named color constants (backgrounds, borders, text, accents, gauge stops)
- **Gauge color interpolation**: 4-segment (0-40 blue, 40-70 cyan, 70-85 amber, 85-100 red) with smooth RGB blending
- **WCAG helpers**: `relative_luminance()` + `contrast_ratio()` for accessibility validation
- **Widget model computed properties**: `value_sweep_degrees()`, `arc_start/end_radians()`, `value_color()`, `normalized_buffer()`, `buffer_min/max()`, `fill_opacity()`, `normalized_cpu/memory()`, `earliest/latest_timestamp()`

### Tests
- **Render**: 42 test functions — blend edge cases, quantize boundaries, style token formula verification, phase wrapping, formatting (empty/null/NaN/huge/clamped), status edge cases, sequencer multi-tick, Qt hooks multi-frame + partial callback rejection, sanitization
- **Shell**: 17 test functions — dock shuffle invariant, panel ordering with explicit indices, same-slot noop, active tab round-trips, to_string coverage, default state checks, out-of-range throws, append semantics
- **Shell test CMake**: Fixed standalone build with `add_subdirectory` for `aura_shell_core`

## Build Verification
- `aura_render_native.dll` — compiles clean (MSVC 2022, C++20)
- `aura_shell.exe` — compiles clean with Qt6 6.10.2
- `render_native_tests` — 1/1 passed (42 test functions)
- `aura_shell_dock_model_tests` + `cockpit_controller_tests` + `timeline_bridge_tests` — 3/3 passed

## Test plan
- [ ] Build render module: `cmake --build build/render-native --config Release`
- [ ] Run render tests: `ctest --test-dir build/render-native-tests -C Release`
- [ ] Build shell: `powershell -ExecutionPolicy Bypass -File installer/windows/build_shell_native.ps1`
- [ ] Run shell tests: `ctest --test-dir build/shell-tests -C Release`
- [ ] Launch GUI: `.\aura.cmd --gui` — verify visual polish, gauge animations, sparklines
- [ ] Verify frameless window drag, minimize, maximize, close
- [ ] Verify panel move (L/C/R buttons) still works
- [ ] Verify tab switching works

🤖 Generated with [Claude Code](https://claude.com/claude-code)