### PR TITLE
feat(shell): add resolution-agnostic layout and premium pink mode

### DIFF
--- a/src/shell/native/include/aura_shell/ui_theme.hpp
+++ b/src/shell/native/include/aura_shell/ui_theme.hpp
@@ -11,6 +11,25 @@ enum class UiThemeMode : std::uint8_t {
     PinkCute = 1,
 };
 
+struct ThemePalette {
+    const char* bg_window;
+    const char* bg_panel;
+    const char* bg_surface;
+    const char* bg_elevated;
+    const char* border_subtle;
+    const char* border_active;
+    const char* border_accent;
+    const char* text_primary;
+    const char* text_secondary;
+    const char* text_muted;
+    const char* accent;
+    const char* accent_hover;
+    const char* danger;
+    const char* danger_hover;
+};
+
+const ThemePalette& get_theme_palette(UiThemeMode mode);
+
 UiThemeMode ui_theme_mode_from_key(std::string_view key);
 std::string ui_theme_mode_key(UiThemeMode mode);
 UiThemeMode toggle_ui_theme_mode(UiThemeMode mode);

--- a/src/shell/native/qml/CockpitScene.qml
+++ b/src/shell/native/qml/CockpitScene.qml
@@ -1,4 +1,5 @@
 import QtQuick 2.15
+import QtQuick.Layouts 1.15
 
 Rectangle {
     id: root
@@ -53,6 +54,19 @@ Rectangle {
         memSparkCanvas.pushSample(smoothMem)
     }
 
+    // ── Color tokens ─────────────────────────────────────────────────────────
+    readonly property color clrBgDeep: pinkMode ? "#150a12" : "#060b14"
+    readonly property color clrAccent: pinkMode ? "#ff4da6" : "#3b82f6"
+    readonly property color clrAccentHover: pinkMode ? "#ff92c5" : "#60a5fa"
+    readonly property color clrTextPrimary: pinkMode ? "#ffe8f5" : "#e0ecf7"
+    readonly property color clrTextMuted: pinkMode ? "#d887b1" : "#4d6d87"
+    readonly property color clrTextSecondary: pinkMode ? "#ffb3d9" : "#8badc4"
+    readonly property color clrTrack: pinkMode ? "#5f2a4b" : "#1a2940"
+    readonly property color clrTrackTick: pinkMode ? "#3a1529" : "#0c1829"
+    readonly property color clrBgGradTop: pinkMode ? "#3a1529" : "#0c1829"
+    readonly property color clrBgGradMid: pinkMode ? "#2a1021" : "#080e18"
+    readonly property color clrBgGradBot: pinkMode ? "#1a0915" : "#050a11"
+
     // ── Derived accent color helpers ─────────────────────────────────────────
     function accentColor(alpha) {
         return Qt.rgba(accentRed, accentGreen, accentBlue, alpha)
@@ -69,7 +83,7 @@ Rectangle {
         return Qt.rgba(accentRed, accentGreen, accentBlue, alpha)
     }
 
-    // Gauge arc color: 0–50 = blue→cyan, 50–80 = cyan→amber, 80–100 = amber→red
+    // Gauge arc color: 0-50 = blue>cyan, 50-80 = cyan>amber, 80-100 = amber>red
     function gaugeColor(pct, alpha) {
         var t, r, g, b
         if (pinkMode) {
@@ -115,11 +129,11 @@ Rectangle {
         )
     }
 
-    // ── Gauge size ────────────────────────────────────────────────────────────
-    property real gaugeSize: Math.min(Math.max(root.width * 0.30, 110), 160)
-
-    // ── Layout constants ──────────────────────────────────────────────────────
-    property real margin: 20
+    // ── Responsive layout properties ─────────────────────────────────────────
+    property real scaledMargin: Math.max(10, root.height * 0.028)
+    property real scaledSpacing: Math.max(4, root.height * 0.012)
+    property real gaugeSize: Math.min(Math.max(root.width * 0.30, 110), 240)
+    property real effectiveGaugeSize: Math.min(gaugeSize, root.height * 0.38)
 
     // =========================================================================
     // LAYER 0 — background vignette / depth
@@ -128,9 +142,9 @@ Rectangle {
         anchors.fill: parent
         radius: root.radius
         gradient: Gradient {
-            GradientStop { position: 0.0; color: root.uiColor("#0c1829", "#3a1529") }
-            GradientStop { position: 0.55; color: root.uiColor("#080e18", "#2a1021") }
-            GradientStop { position: 1.0; color: root.uiColor("#050a11", "#1a0915") }
+            GradientStop { position: 0.0; color: root.clrBgGradTop }
+            GradientStop { position: 0.55; color: root.clrBgGradMid }
+            GradientStop { position: 1.0; color: root.clrBgGradBot }
         }
     }
 
@@ -145,41 +159,162 @@ Rectangle {
         }
     }
 
-    // Cute decorative accents for pink mode (kept outside metric focus area).
+    // Canvas decorative accents for pink mode
     Item {
         anchors.fill: parent
         visible: root.pinkMode
         z: 0
-        opacity: 0.22
+        opacity: 0.72
 
-        Text {
-            text: "\uD83E\uDDF8"
+        // 6-pointed star — top-left
+        Canvas {
+            id: starDecor
             anchors.left: parent.left
             anchors.top: parent.top
-            anchors.leftMargin: 18
-            anchors.topMargin: 14
-            font.pixelSize: 24
-            color: "#ffd3e7"
+            anchors.leftMargin: 12
+            anchors.topMargin: 10
+            width: Math.max(18, root.width * 0.04)
+            height: width
+            onPaint: {
+                var ctx = getContext("2d")
+                ctx.clearRect(0, 0, width, height)
+                var cx = width / 2, cy = height / 2
+                var outer = width * 0.45, inner = width * 0.22
+                // Inner glow ring
+                ctx.beginPath()
+                ctx.arc(cx, cy, outer * 0.7, 0, Math.PI * 2)
+                ctx.strokeStyle = Qt.rgba(1, 0.3, 0.65, 0.25)
+                ctx.lineWidth = 1.5
+                ctx.stroke()
+                // 6-pointed star
+                ctx.beginPath()
+                for (var i = 0; i < 12; i++) {
+                    var angle = (i * Math.PI / 6) - Math.PI / 2
+                    var r = (i % 2 === 0) ? outer : inner
+                    var px = cx + r * Math.cos(angle)
+                    var py = cy + r * Math.sin(angle)
+                    if (i === 0) ctx.moveTo(px, py)
+                    else ctx.lineTo(px, py)
+                }
+                ctx.closePath()
+                var grad = ctx.createRadialGradient(cx, cy, 0, cx, cy, outer)
+                grad.addColorStop(0.0, "#ff92c5")
+                grad.addColorStop(1.0, "#ff4da6")
+                ctx.fillStyle = grad
+                ctx.fill()
+            }
+            Connections {
+                target: root
+                function onWidthChanged() { starDecor.requestPaint() }
+            }
         }
-        Text {
-            text: "\uD83C\uDF70"
+
+        // Diamond facet — top-right
+        Canvas {
+            id: diamondDecor
             anchors.right: parent.right
             anchors.top: parent.top
-            anchors.rightMargin: 20
-            anchors.topMargin: 14
-            font.pixelSize: 22
-            color: "#ffd3e7"
+            anchors.rightMargin: 14
+            anchors.topMargin: 10
+            width: Math.max(16, root.width * 0.035)
+            height: width
+            onPaint: {
+                var ctx = getContext("2d")
+                ctx.clearRect(0, 0, width, height)
+                var cx = width / 2, cy = height / 2, s = width * 0.42
+                ctx.save()
+                ctx.translate(cx, cy)
+                ctx.rotate(Math.PI / 4)
+                // Outer diamond
+                ctx.beginPath()
+                ctx.rect(-s, -s, s * 2, s * 2)
+                var grad = ctx.createLinearGradient(-s, -s, s, s)
+                grad.addColorStop(0.0, "#ff4da6")
+                grad.addColorStop(1.0, "#ff92c5")
+                ctx.fillStyle = grad
+                ctx.fill()
+                // Inner highlight
+                var hs = s * 0.5
+                ctx.beginPath()
+                ctx.rect(-hs, -hs, hs * 2, hs * 2)
+                ctx.fillStyle = Qt.rgba(1, 1, 1, 0.18)
+                ctx.fill()
+                ctx.restore()
+            }
+            Connections {
+                target: root
+                function onWidthChanged() { diamondDecor.requestPaint() }
+            }
         }
-        Text {
-            text: "\u2665"
+
+        // Heart cluster — bottom-right
+        Canvas {
+            id: heartDecor
             anchors.right: parent.right
             anchors.bottom: parent.bottom
-            anchors.rightMargin: 22
-            anchors.bottomMargin: 14
-            font.pixelSize: 16
-            color: "#ff9cc5"
+            anchors.rightMargin: 14
+            anchors.bottomMargin: 10
+            width: Math.max(24, root.width * 0.05)
+            height: width * 0.8
+            onPaint: {
+                var ctx = getContext("2d")
+                ctx.clearRect(0, 0, width, height)
+
+                function drawHeart(cx, cy, sz, clr) {
+                    ctx.save()
+                    ctx.translate(cx, cy)
+                    ctx.beginPath()
+                    ctx.moveTo(0, sz * 0.3)
+                    ctx.bezierCurveTo(-sz * 0.5, -sz * 0.3, -sz, sz * 0.1, 0, sz)
+                    ctx.moveTo(0, sz * 0.3)
+                    ctx.bezierCurveTo(sz * 0.5, -sz * 0.3, sz, sz * 0.1, 0, sz)
+                    ctx.fillStyle = clr
+                    ctx.fill()
+                    ctx.restore()
+                }
+
+                var base = width * 0.28
+                drawHeart(width * 0.55, height * 0.10, base * 1.0, "#ff4da6")
+                drawHeart(width * 0.25, height * 0.30, base * 0.7, "#ff92c5")
+                drawHeart(width * 0.72, height * 0.42, base * 0.55, "#d887b1")
+            }
+            Connections {
+                target: root
+                function onWidthChanged() { heartDecor.requestPaint() }
+            }
+        }
+
+        // Dot rail — left edge
+        Canvas {
+            id: dotRailDecor
+            anchors.left: parent.left
+            anchors.verticalCenter: parent.verticalCenter
+            anchors.leftMargin: 6
+            width: 8
+            height: Math.max(40, root.height * 0.12)
+            onPaint: {
+                var ctx = getContext("2d")
+                ctx.clearRect(0, 0, width, height)
+                var cx = width / 2
+                var spacing = height / 6
+                for (var i = 0; i < 5; i++) {
+                    var dy = spacing * (i + 1)
+                    var isCenter = (i === 2)
+                    var r = isCenter ? 3.0 : 1.8
+                    var alpha = isCenter ? 0.85 : 0.50
+                    ctx.beginPath()
+                    ctx.arc(cx, dy, r, 0, Math.PI * 2)
+                    ctx.fillStyle = Qt.rgba(1.0, 0.30, 0.65, alpha)
+                    ctx.fill()
+                }
+            }
+            Connections {
+                target: root
+                function onHeightChanged() { dotRailDecor.requestPaint() }
+            }
         }
     }
+
     // =========================================================================
     // LAYER 1 — frosted-glass panel surface
     // =========================================================================
@@ -211,24 +346,28 @@ Rectangle {
     }
 
     // =========================================================================
-    // CONTENT COLUMN
+    // CONTENT COLUMN — ColumnLayout for responsive sizing
     // =========================================================================
-    Column {
+    ColumnLayout {
         id: contentColumn
-        anchors { left: parent.left; right: parent.right; top: parent.top; topMargin: root.margin }
+        anchors.fill: parent
+        anchors.topMargin: root.scaledMargin
+        anchors.leftMargin: 0
+        anchors.rightMargin: 0
+        anchors.bottomMargin: 0
         spacing: 0
 
         // ── Title band ───────────────────────────────────────────────────────
         Item {
-            width: parent.width
-            height: 28
+            Layout.fillWidth: true
+            Layout.preferredHeight: Math.max(22, root.height * 0.055)
 
             Text {
                 id: titleLabel
                 text: "AURA  COCKPIT"
                 anchors.centerIn: parent
-                color: root.uiColor("#4a6d8a", "#e2a2c5")
-                font.pixelSize: 11
+                color: root.clrTextMuted
+                font.pixelSize: Math.max(9, root.height * 0.022)
                 font.weight: Font.Medium
                 font.letterSpacing: 4
             }
@@ -242,21 +381,21 @@ Rectangle {
             }
         }
 
-        Item { width: 1; height: 14 } // spacer
+        Item { Layout.preferredHeight: root.scaledSpacing; Layout.fillWidth: true }
 
         // ── Gauge pair ───────────────────────────────────────────────────────
         Row {
             id: gaugeRow
-            anchors.horizontalCenter: parent.horizontalCenter
+            Layout.alignment: Qt.AlignHCenter
             spacing: Math.max(root.width * 0.08, 24)
 
             // ── CPU gauge ────────────────────────────────────────────────────
             Item {
                 id: cpuGaugeItem
-                width: root.gaugeSize
-                height: root.gaugeSize
+                width: root.effectiveGaugeSize
+                height: root.effectiveGaugeSize
 
-                // Outer glow halo — drawn first (behind)
+                // Outer glow halo
                 Canvas {
                     id: cpuGlowCanvas
                     anchors.centerIn: parent
@@ -304,20 +443,20 @@ Rectangle {
                         var cy = height / 2
                         var r  = width  / 2 - 10
                         var trackW = 11
-                        var startAngle = Math.PI * 0.75            // 135°
-                        var fullSweep  = Math.PI * 1.50            // 270°
+                        var startAngle = Math.PI * 0.75
+                        var fullSweep  = Math.PI * 1.50
                         var endAngle   = startAngle + fullSweep * (root.smoothCpu / 100.0)
 
                         // Track arc
                         ctx.beginPath()
                         ctx.arc(cx, cy, r, startAngle, startAngle + fullSweep, false)
-                        ctx.strokeStyle = root.uiColor("#1a2940", "#5f2a4b")
+                        ctx.strokeStyle = root.clrTrack
                         ctx.lineWidth   = trackW
                         ctx.lineCap     = "butt"
                         ctx.stroke()
 
                         // Tick marks at 25%, 50%, 75%
-                        ctx.strokeStyle = root.uiColor("#0c1829", "#3a1529")
+                        ctx.strokeStyle = root.clrTrackTick
                         ctx.lineWidth   = 2
                         var ticks = [0.25, 0.50, 0.75]
                         for (var i = 0; i < ticks.length; i++) {
@@ -374,16 +513,16 @@ Rectangle {
                     Text {
                         anchors.horizontalCenter: parent.horizontalCenter
                         text: root.smoothCpu.toFixed(0) + "%"
-                        color: root.uiColor("#e8f4ff", "#fff1f8")
-                        font.pixelSize: Math.max(22, root.gaugeSize * 0.20)
+                        color: root.clrTextPrimary
+                        font.pixelSize: Math.max(22, root.effectiveGaugeSize * 0.20)
                         font.weight: Font.Bold
                     }
 
                     Text {
                         anchors.horizontalCenter: parent.horizontalCenter
                         text: "CPU"
-                        color: root.uiColor("#7ba8c8", "#f2bfd8")
-                        font.pixelSize: 9
+                        color: root.clrTextSecondary
+                        font.pixelSize: Math.max(8, root.height * 0.018)
                         font.weight: Font.Medium
                         font.letterSpacing: 2.5
                     }
@@ -393,8 +532,8 @@ Rectangle {
             // ── Memory gauge ─────────────────────────────────────────────────
             Item {
                 id: memGaugeItem
-                width: root.gaugeSize
-                height: root.gaugeSize
+                width: root.effectiveGaugeSize
+                height: root.effectiveGaugeSize
 
                 // Outer glow halo
                 Canvas {
@@ -450,13 +589,13 @@ Rectangle {
                         // Track arc
                         ctx.beginPath()
                         ctx.arc(cx, cy, r, startAngle, startAngle + fullSweep, false)
-                        ctx.strokeStyle = root.uiColor("#1a2940", "#5f2a4b")
+                        ctx.strokeStyle = root.clrTrack
                         ctx.lineWidth   = trackW
                         ctx.lineCap     = "butt"
                         ctx.stroke()
 
                         // Tick marks
-                        ctx.strokeStyle = root.uiColor("#0c1829", "#3a1529")
+                        ctx.strokeStyle = root.clrTrackTick
                         var ticks = [0.25, 0.50, 0.75]
                         for (var i = 0; i < ticks.length; i++) {
                             var ta = startAngle + fullSweep * ticks[i]
@@ -512,16 +651,16 @@ Rectangle {
                     Text {
                         anchors.horizontalCenter: parent.horizontalCenter
                         text: root.smoothMem.toFixed(0) + "%"
-                        color: root.uiColor("#e8f4ff", "#fff1f8")
-                        font.pixelSize: Math.max(22, root.gaugeSize * 0.20)
+                        color: root.clrTextPrimary
+                        font.pixelSize: Math.max(22, root.effectiveGaugeSize * 0.20)
                         font.weight: Font.Bold
                     }
 
                     Text {
                         anchors.horizontalCenter: parent.horizontalCenter
                         text: "MEM"
-                        color: root.uiColor("#7ba8c8", "#f2bfd8")
-                        font.pixelSize: 9
+                        color: root.clrTextSecondary
+                        font.pixelSize: Math.max(8, root.height * 0.018)
                         font.weight: Font.Medium
                         font.letterSpacing: 2.5
                     }
@@ -529,12 +668,12 @@ Rectangle {
             }
         } // Row gaugeRow
 
-        Item { width: 1; height: 16 } // spacer
+        Item { Layout.preferredHeight: root.scaledSpacing * 1.3; Layout.fillWidth: true }
 
         // ── Section divider ──────────────────────────────────────────────────
         Item {
-            width: parent.width
-            height: 1
+            Layout.fillWidth: true
+            Layout.preferredHeight: 1
 
             Rectangle {
                 anchors.centerIn: parent
@@ -550,21 +689,24 @@ Rectangle {
             }
         }
 
-        Item { width: 1; height: 14 } // spacer
+        Item { Layout.preferredHeight: root.scaledSpacing; Layout.fillWidth: true }
 
         // ── Sparkline — CPU ──────────────────────────────────────────────────
         Item {
             id: cpuSparkRow
-            anchors { left: parent.left; right: parent.right; leftMargin: root.margin; rightMargin: root.margin }
-            height: 64
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            Layout.minimumHeight: 48
+            Layout.leftMargin: root.scaledMargin
+            Layout.rightMargin: root.scaledMargin
 
             // Label row
             Text {
                 id: cpuSparkLabel
-                anchors { left: parent.left; verticalCenter: undefined; top: parent.top }
+                anchors { left: parent.left; top: parent.top }
                 text: "CPU  HISTORY"
-                color: root.uiColor("#4a6d8a", "#e2a2c5")
-                font.pixelSize: 9
+                color: root.clrTextMuted
+                font.pixelSize: Math.max(8, root.height * 0.018)
                 font.weight: Font.Medium
                 font.letterSpacing: 2.5
             }
@@ -573,7 +715,7 @@ Rectangle {
                 anchors { right: parent.right; top: parent.top }
                 text: root.smoothCpu.toFixed(1) + "%"
                 color: root.gaugeColor(root.smoothCpu, 1.0)
-                font.pixelSize: 10
+                font.pixelSize: Math.max(9, root.height * 0.020)
                 font.weight: Font.Bold
                 font.letterSpacing: 0.5
             }
@@ -603,7 +745,6 @@ Rectangle {
                     var cw  = width
                     var ch  = height - pad
 
-                    // Build point array
                     var pts = []
                     for (var i = 0; i < n; i++) {
                         var x = (i / (n - 1)) * cw
@@ -664,19 +805,22 @@ Rectangle {
             }
         }
 
-        Item { width: 1; height: 8 } // spacer
+        Item { Layout.preferredHeight: root.scaledSpacing * 0.6; Layout.fillWidth: true }
 
         // ── Sparkline — Memory ───────────────────────────────────────────────
         Item {
             id: memSparkRow
-            anchors { left: parent.left; right: parent.right; leftMargin: root.margin; rightMargin: root.margin }
-            height: 64
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            Layout.minimumHeight: 48
+            Layout.leftMargin: root.scaledMargin
+            Layout.rightMargin: root.scaledMargin
 
             Text {
                 anchors { left: parent.left; top: parent.top }
                 text: "MEM  HISTORY"
-                color: root.uiColor("#4a6d8a", "#e2a2c5")
-                font.pixelSize: 9
+                color: root.clrTextMuted
+                font.pixelSize: Math.max(8, root.height * 0.018)
                 font.weight: Font.Medium
                 font.letterSpacing: 2.5
             }
@@ -685,7 +829,7 @@ Rectangle {
                 anchors { right: parent.right; top: parent.top }
                 text: root.smoothMem.toFixed(1) + "%"
                 color: root.gaugeColor(root.smoothMem, 1.0)
-                font.pixelSize: 10
+                font.pixelSize: Math.max(9, root.height * 0.020)
                 font.weight: Font.Bold
                 font.letterSpacing: 0.5
             }
@@ -721,7 +865,7 @@ Rectangle {
                         pts.push({x: x, y: y})
                     }
 
-                    // Filled area — memory uses a slightly warmer tint to visually separate
+                    // Filled area
                     ctx.beginPath()
                     ctx.moveTo(pts[0].x, pts[0].y)
                     for (var j = 1; j < n - 1; j++) {
@@ -734,7 +878,6 @@ Rectangle {
                     ctx.lineTo(0, ch + pad)
                     ctx.closePath()
 
-                    // Memory sparkline: tint shifted toward cyan regardless of accent
                     var fillGrad = ctx.createLinearGradient(0, 0, 0, ch)
                     fillGrad.addColorStop(0.0, Qt.rgba(0.15, 0.65, 0.78, 0.28))
                     fillGrad.addColorStop(1.0, Qt.rgba(0.15, 0.65, 0.78, 0.02))
@@ -764,12 +907,12 @@ Rectangle {
             }
         }
 
-        Item { width: 1; height: 10 } // spacer
+        Item { Layout.preferredHeight: root.scaledSpacing * 0.8; Layout.fillWidth: true }
 
         // ── Final divider ────────────────────────────────────────────────────
         Item {
-            width: parent.width
-            height: 1
+            Layout.fillWidth: true
+            Layout.preferredHeight: 1
 
             Rectangle {
                 anchors.centerIn: parent
@@ -785,11 +928,11 @@ Rectangle {
             }
         }
 
-        Item { width: 1; height: 10 } // spacer
+        Item { Layout.preferredHeight: root.scaledSpacing * 0.8; Layout.fillWidth: true }
 
         // ── Status line ──────────────────────────────────────────────────────
         Row {
-            anchors.horizontalCenter: parent.horizontalCenter
+            Layout.alignment: Qt.AlignHCenter
             spacing: 6
 
             // Pulse indicator dot
@@ -812,8 +955,8 @@ Rectangle {
             Text {
                 id: statusLabel
                 text: root.statusText
-                color: root.uiColor("#4a6d8a", "#e2a2c5")
-                font.pixelSize: 10
+                color: root.clrTextMuted
+                font.pixelSize: Math.max(9, root.height * 0.020)
                 font.letterSpacing: 0.5
                 elide: Text.ElideRight
                 width: root.width * 0.75
@@ -821,7 +964,7 @@ Rectangle {
             }
         }
 
-        Item { width: 1; height: root.margin } // bottom padding
+        Item { Layout.preferredHeight: root.scaledMargin; Layout.fillWidth: true }
     } // contentColumn
 
     // =========================================================================
@@ -875,5 +1018,3 @@ Rectangle {
         }
     }
 }
-
-

--- a/src/shell/native/src/main.cpp
+++ b/src/shell/native/src/main.cpp
@@ -12,6 +12,7 @@
 #include <QPushButton>
 #include <QQuickItem>
 #include <QQuickWidget>
+#include <QScreen>
 #include <QScrollArea>
 #include <QSettings>
 #include <QSizePolicy>
@@ -38,24 +39,6 @@
 #include "aura_shell/ui_theme.hpp"
 
 namespace {
-
-// ---------------------------------------------------------------------------
-// Color palette — all depth levels and accent colors in one place so the
-// stylesheet strings below stay readable and consistent.
-// ---------------------------------------------------------------------------
-//  Depth 0  (window bg)  : #060b14
-//  Depth 1  (panels)     : #0a1221
-//  Depth 2  (surfaces)   : #0f1a2e
-//  Depth 3  (elevated)   : #162238
-//  Border subtle         : #1e3350
-//  Border active         : #2a4a6e
-//  Text primary          : #e0ecf7
-//  Text secondary        : #8badc4
-//  Text muted            : #4d6d87
-//  Accent blue           : #3b82f6
-//  Accent blue hover     : #60a5fa
-//  Danger (close)        : #ef4444
-//  Danger hover          : #f87171
 
 // ---------------------------------------------------------------------------
 
@@ -208,376 +191,338 @@ struct SlotWidgets {
     QStackedWidget* stack;
 };
 
-// ---------------------------------------------------------------------------
-// Comprehensive application stylesheet
-// ---------------------------------------------------------------------------
-static const QString k_app_stylesheet_dark_blue = QStringLiteral(
-    // --- Application-wide base ---
-    "* {"
-    "    font-family: 'Segoe UI';"
-    "    font-size: 11px;"
-    "    color: #e0ecf7;"
-    "}"
-
-    // --- Main window ---
-    "QMainWindow {"
-    "    background: #060b14;"
-    "}"
-
-    // --- Title bar ---
-    "QFrame#titlebar {"
-    "    background: qlineargradient("
-    "        x1:0, y1:0, x2:0, y2:1,"
-    "        stop:0 #0f1a2e,"
-    "        stop:1 #0a1221"
-    "    );"
-    "    border-bottom: 1px solid #1e3350;"
-    "    min-height: 36px;"
-    "    max-height: 36px;"
-    "}"
-
-    // --- App logo label in title bar ---
-    "QLabel#appLogo {"
-    "    color: #3b82f6;"
-    "    font-size: 13px;"
-    "    font-weight: 600;"
-    "    letter-spacing: 2px;"
-    "    padding-left: 4px;"
-    "}"
-
-    // --- Title bar subtitle ---
-    "QLabel#titleSubtitle {"
-    "    color: #4d6d87;"
-    "    font-size: 10px;"
-    "    letter-spacing: 1px;"
-    "    padding-left: 8px;"
-    "}"
-
-    // --- Title bar window-control buttons ---
-    "QPushButton#minBtn, QPushButton#maxBtn {"
-    "    background: transparent;"
-    "    color: #8badc4;"
-    "    border: none;"
-    "    border-radius: 4px;"
-    "    min-width: 28px;"
-    "    max-width: 28px;"
-    "    min-height: 24px;"
-    "    max-height: 24px;"
-    "    font-size: 13px;"
-    "    padding: 0px;"
-    "}"
-    "QPushButton#minBtn:hover {"
-    "    background: #162238;"
-    "    color: #e0ecf7;"
-    "}"
-    "QPushButton#maxBtn:hover {"
-    "    background: #162238;"
-    "    color: #e0ecf7;"
-    "}"
-    "QPushButton#closeBtn {"
-    "    background: transparent;"
-    "    color: #8badc4;"
-    "    border: none;"
-    "    border-radius: 4px;"
-    "    min-width: 28px;"
-    "    max-width: 28px;"
-    "    min-height: 24px;"
-    "    max-height: 24px;"
-    "    font-size: 13px;"
-    "    padding: 0px;"
-    "    margin-right: 4px;"
-    "}"
-    "QPushButton#closeBtn:hover {"
-    "    background: #ef4444;"
-    "    color: #ffffff;"
-    "}"
-    "QPushButton#closeBtn:pressed {"
-    "    background: #b91c1c;"
-    "    color: #ffffff;"
-    "}"
-
-    // --- Theme switch in title bar ---
-    "QPushButton#themeToggleBtn {"
-    "    background: #0f1a2e;"
-    "    color: #8badc4;"
-    "    border: 1px solid #1e3350;"
-    "    border-radius: 6px;"
-    "    min-height: 24px;"
-    "    padding: 0px 10px;"
-    "    font-size: 10px;"
-    "    font-weight: 600;"
-    "}"
-    "QPushButton#themeToggleBtn:hover {"
-    "    background: #162238;"
-    "    color: #e0ecf7;"
-    "    border-color: #3b82f6;"
-    "}"
-    "QPushButton#themeToggleBtn:pressed {"
-    "    background: #1e3350;"
-    "    color: #60a5fa;"
-    "    border-color: #3b82f6;"
-    "}"
-
-    // --- Dock slot frames ---
-    "QFrame#slot {"
-    "    background: #0a1221;"
-    "    border: 1px solid #1e3350;"
-    "    border-radius: 10px;"
-    "    padding: 0px;"
-    "}"
-
-    // --- Slot zone label (LEFT / CENTER / RIGHT) ---
-    "QLabel#slotZoneLabel {"
-    "    color: #2a4a6e;"
-    "    font-size: 9px;"
-    "    font-weight: 600;"
-    "    letter-spacing: 3px;"
-    "    padding: 0px 0px 0px 2px;"
-    "}"
-
-    // --- Tab bar ---
-    "QTabBar {"
-    "    background: transparent;"
-    "    border: none;"
-    "    border-bottom: 1px solid #1e3350;"
-    "}"
-    "QTabBar::tab {"
-    "    background: transparent;"
-    "    color: #4d6d87;"
-    "    border: none;"
-    "    border-bottom: 2px solid transparent;"
-    "    padding: 7px 16px 6px 16px;"
-    "    font-size: 11px;"
-    "    font-weight: 500;"
-    "    letter-spacing: 0.5px;"
-    "    min-width: 60px;"
-    "}"
-    "QTabBar::tab:hover {"
-    "    color: #8badc4;"
-    "    border-bottom: 2px solid #2a4a6e;"
-    "}"
-    "QTabBar::tab:selected {"
-    "    color: #e0ecf7;"
-    "    border-bottom: 2px solid #3b82f6;"
-    "    font-weight: 600;"
-    "}"
-    "QTabBar::tab:!enabled {"
-    "    color: #2a4a6e;"
-    "}"
-
-    // --- Generic QPushButton (move buttons etc.) ---
-    "QPushButton {"
-    "    background: #0f1a2e;"
-    "    color: #8badc4;"
-    "    border: 1px solid #1e3350;"
-    "    border-radius: 6px;"
-    "    padding: 3px 10px;"
-    "    font-size: 11px;"
-    "}"
-    "QPushButton:hover {"
-    "    background: #162238;"
-    "    color: #e0ecf7;"
-    "    border-color: #2a4a6e;"
-    "}"
-    "QPushButton:pressed {"
-    "    background: #1e3350;"
-    "    color: #60a5fa;"
-    "    border-color: #3b82f6;"
-    "}"
-    "QPushButton:disabled {"
-    "    background: #060b14;"
-    "    color: #2a4a6e;"
-    "    border-color: #1e3350;"
-    "}"
-
-    // --- Panel move pill buttons ---
-    "QPushButton#moveBtn {"
-    "    background: #0f1a2e;"
-    "    color: #4d6d87;"
-    "    border: 1px solid #1e3350;"
-    "    border-radius: 10px;"
-    "    padding: 2px 9px;"
-    "    font-size: 10px;"
-    "    font-weight: 600;"
-    "    min-width: 22px;"
-    "    max-height: 20px;"
-    "}"
-    "QPushButton#moveBtn:hover {"
-    "    background: #162238;"
-    "    color: #60a5fa;"
-    "    border-color: #3b82f6;"
-    "}"
-    "QPushButton#moveBtn:disabled {"
-    "    background: #060b14;"
-    "    color: #1e3350;"
-    "    border-color: #0f1a2e;"
-    "}"
-
-    // --- Panel header separator line ---
-    "QFrame#panelHeaderLine {"
-    "    background: qlineargradient("
-    "        x1:0, y1:0, x2:1, y2:0,"
-    "        stop:0 #3b82f6,"
-    "        stop:0.4 #1e3350,"
-    "        stop:1 transparent"
-    "    );"
-    "    min-height: 1px;"
-    "    max-height: 1px;"
-    "    border: none;"
-    "}"
-
-    // --- Panel title label ---
-    "QLabel#panelTitle {"
-    "    color: #e0ecf7;"
-    "    font-size: 12px;"
-    "    font-weight: 600;"
-    "    letter-spacing: 1px;"
-    "}"
-
-    // --- "Move to:" prompt label ---
-    "QLabel#moveToLabel {"
-    "    color: #4d6d87;"
-    "    font-size: 9px;"
-    "    letter-spacing: 1px;"
-    "}"
-
-    // --- Telemetry metric labels ---
-    "QLabel#metricValue {"
-    "    color: #e0ecf7;"
-    "    font-size: 20px;"
-    "    font-weight: 700;"
-    "    letter-spacing: -0.5px;"
-    "}"
-    "QLabel#metricKey {"
-    "    color: #4d6d87;"
-    "    font-size: 9px;"
-    "    font-weight: 600;"
-    "    letter-spacing: 2px;"
-    "}"
-    "QLabel#metricUnit {"
-    "    color: #3b82f6;"
-    "    font-size: 12px;"
-    "    font-weight: 600;"
-    "}"
-
-    // --- Telemetry timestamp ---
-    "QLabel#telemetryTimestamp {"
-    "    color: #4d6d87;"
-    "    font-size: 10px;"
-    "}"
-
-    // --- Telemetry status ---
-    "QLabel#telemetryStatus {"
-    "    color: #8badc4;"
-    "    font-size: 10px;"
-    "    font-style: italic;"
-    "}"
-
-    // --- Process panel status label ---
-    "QLabel#processStatus {"
-    "    color: #4d6d87;"
-    "    font-size: 10px;"
-    "    font-style: italic;"
-    "    padding-bottom: 4px;"
-    "}"
-
-    // --- Process row labels (monospace) ---
-    "QLabel#processRow {"
-    "    color: #8badc4;"
-    "    font-family: 'Cascadia Mono', 'Consolas', monospace;"
-    "    font-size: 10px;"
-    "    padding: 3px 6px;"
-    "    border-radius: 3px;"
-    "}"
-    "QLabel#processRowAlt {"
-    "    color: #8badc4;"
-    "    font-family: 'Cascadia Mono', 'Consolas', monospace;"
-    "    font-size: 10px;"
-    "    background: #0a1221;"
-    "    padding: 3px 6px;"
-    "    border-radius: 3px;"
-    "}"
-
-    // --- Timeline and render status labels ---
-    "QLabel#timelineStatus {"
-    "    color: #4d6d87;"
-    "    font-size: 10px;"
-    "    font-style: italic;"
-    "}"
-    "QLabel#renderStatus {"
-    "    color: #4d6d87;"
-    "    font-size: 10px;"
-    "    font-style: italic;"
-    "}"
-
-    // --- Footer status bar ---
-    "QLabel#footerStatus {"
-    "    color: #2a4a6e;"
-    "    font-size: 9px;"
-    "    font-family: 'Cascadia Mono', 'Consolas', monospace;"
-    "    padding: 4px 12px 8px 14px;"
-    "    border-left: 2px solid #3b82f6;"
-    "    margin-left: 12px;"
-    "    margin-bottom: 4px;"
-    "}"
-
-    // --- Thin scrollbars ---
-    "QScrollBar:vertical {"
-    "    background: #060b14;"
-    "    width: 6px;"
-    "    border-radius: 3px;"
-    "    margin: 0px;"
-    "}"
-    "QScrollBar::handle:vertical {"
-    "    background: #1e3350;"
-    "    border-radius: 3px;"
-    "    min-height: 20px;"
-    "}"
-    "QScrollBar::handle:vertical:hover {"
-    "    background: #2a4a6e;"
-    "}"
-    "QScrollBar::add-line:vertical, QScrollBar::sub-line:vertical {"
-    "    height: 0px;"
-    "}"
-    "QScrollBar:horizontal {"
-    "    background: #060b14;"
-    "    height: 6px;"
-    "    border-radius: 3px;"
-    "    margin: 0px;"
-    "}"
-    "QScrollBar::handle:horizontal {"
-    "    background: #1e3350;"
-    "    border-radius: 3px;"
-    "    min-width: 20px;"
-    "}"
-    "QScrollBar::handle:horizontal:hover {"
-    "    background: #2a4a6e;"
-    "}"
-    "QScrollBar::add-line:horizontal, QScrollBar::sub-line:horizontal {"
-    "    width: 0px;"
-    "}"
-);
-
 constexpr const char* k_theme_mode_setting_key = "ui/theme_mode";
 
 QString build_app_stylesheet(const aura::shell::UiThemeMode mode) {
-    if (mode == aura::shell::UiThemeMode::DarkBlue) {
-        return k_app_stylesheet_dark_blue;
-    }
-
-    QString pink = k_app_stylesheet_dark_blue;
-    pink.replace("#060b14", "#190914");
-    pink.replace("#0a1221", "#2a1021");
-    pink.replace("#0f1a2e", "#35162a");
-    pink.replace("#162238", "#46203a");
-    pink.replace("#1e3350", "#6c2d55");
-    pink.replace("#2a4a6e", "#91406f");
-    pink.replace("#3b82f6", "#ff68a8");
-    pink.replace("#60a5fa", "#ff92c5");
-    pink.replace("#e0ecf7", "#ffeaf4");
-    pink.replace("#8badc4", "#ffc6df");
-    pink.replace("#4d6d87", "#d887b1");
-    return pink;
+    const auto& p = aura::shell::get_theme_palette(mode);
+    return QString(
+        // --- Application-wide base ---
+        "* {"
+        "    font-family: 'Segoe UI';"
+        "    font-size: 11px;"
+        "    color: %1;"
+        "}"
+        // --- Main window ---
+        "QMainWindow {"
+        "    background: %2;"
+        "}"
+        // --- Title bar ---
+        "QFrame#titlebar {"
+        "    background: qlineargradient("
+        "        x1:0, y1:0, x2:0, y2:1,"
+        "        stop:0 %3,"
+        "        stop:1 %4"
+        "    );"
+        "    border-bottom: 1px solid %5;"
+        "    min-height: 36px;"
+        "    max-height: 36px;"
+        "}"
+        // --- App logo ---
+        "QLabel#appLogo {"
+        "    color: %6;"
+        "    font-size: 13px;"
+        "    font-weight: 600;"
+        "    letter-spacing: 2px;"
+        "    padding-left: 4px;"
+        "}"
+        // --- Subtitle ---
+        "QLabel#titleSubtitle {"
+        "    color: %7;"
+        "    font-size: 10px;"
+        "    letter-spacing: 1px;"
+        "    padding-left: 8px;"
+        "}"
+        // --- Window control buttons ---
+        "QPushButton#minBtn, QPushButton#maxBtn {"
+        "    background: transparent;"
+        "    color: %8;"
+        "    border: none;"
+        "    border-radius: 4px;"
+        "    min-width: 28px; max-width: 28px;"
+        "    min-height: 24px; max-height: 24px;"
+        "    font-size: 13px;"
+        "    padding: 0px;"
+        "}"
+        "QPushButton#minBtn:hover, QPushButton#maxBtn:hover {"
+        "    background: %9;"
+        "    color: %1;"
+        "}"
+        "QPushButton#closeBtn {"
+        "    background: transparent;"
+        "    color: %8;"
+        "    border: none;"
+        "    border-radius: 4px;"
+        "    min-width: 28px; max-width: 28px;"
+        "    min-height: 24px; max-height: 24px;"
+        "    font-size: 13px;"
+        "    padding: 0px;"
+        "    margin-right: 4px;"
+        "}"
+        "QPushButton#closeBtn:hover {"
+        "    background: %10;"
+        "    color: #ffffff;"
+        "}"
+        "QPushButton#closeBtn:pressed {"
+        "    background: #b91c1c;"
+        "    color: #ffffff;"
+        "}"
+        // --- Theme toggle ---
+        "QPushButton#themeToggleBtn {"
+        "    background: %3;"
+        "    color: %8;"
+        "    border: 1px solid %5;"
+        "    border-radius: 6px;"
+        "    min-height: 24px;"
+        "    padding: 0px 10px;"
+        "    font-size: 10px;"
+        "    font-weight: 600;"
+        "}"
+        "QPushButton#themeToggleBtn:hover {"
+        "    background: %9;"
+        "    color: %1;"
+        "    border-color: %6;"
+        "}"
+        "QPushButton#themeToggleBtn:pressed {"
+        "    background: %5;"
+        "    color: %11;"
+        "    border-color: %6;"
+        "}"
+        // --- Dock slot frames ---
+        "QFrame#slot {"
+        "    background: %4;"
+        "    border: 1px solid %5;"
+        "    border-radius: 10px;"
+        "    padding: 0px;"
+        "}"
+        // --- Slot zone label ---
+        "QLabel#slotZoneLabel {"
+        "    color: %12;"
+        "    font-size: 9px;"
+        "    font-weight: 600;"
+        "    letter-spacing: 3px;"
+        "    padding: 0px 0px 0px 2px;"
+        "}"
+        // --- Tab bar ---
+        "QTabBar {"
+        "    background: transparent;"
+        "    border: none;"
+        "    border-bottom: 1px solid %5;"
+        "}"
+        "QTabBar::tab {"
+        "    background: transparent;"
+        "    color: %7;"
+        "    border: none;"
+        "    border-bottom: 2px solid transparent;"
+        "    padding: 7px 16px 6px 16px;"
+        "    font-size: 11px;"
+        "    font-weight: 500;"
+        "    letter-spacing: 0.5px;"
+        "    min-width: 60px;"
+        "}"
+        "QTabBar::tab:hover {"
+        "    color: %8;"
+        "    border-bottom: 2px solid %12;"
+        "}"
+        "QTabBar::tab:selected {"
+        "    color: %1;"
+        "    border-bottom: 2px solid %6;"
+        "    font-weight: 600;"
+        "}"
+        "QTabBar::tab:!enabled {"
+        "    color: %12;"
+        "}"
+        // --- Generic QPushButton ---
+        "QPushButton {"
+        "    background: %3;"
+        "    color: %8;"
+        "    border: 1px solid %5;"
+        "    border-radius: 6px;"
+        "    padding: 3px 10px;"
+        "    font-size: 11px;"
+        "}"
+        "QPushButton:hover {"
+        "    background: %9;"
+        "    color: %1;"
+        "    border-color: %12;"
+        "}"
+        "QPushButton:pressed {"
+        "    background: %5;"
+        "    color: %11;"
+        "    border-color: %6;"
+        "}"
+        "QPushButton:disabled {"
+        "    background: %2;"
+        "    color: %12;"
+        "    border-color: %5;"
+        "}"
+        // --- Move pill buttons ---
+        "QPushButton#moveBtn {"
+        "    background: %3;"
+        "    color: %7;"
+        "    border: 1px solid %5;"
+        "    border-radius: 10px;"
+        "    padding: 2px 9px;"
+        "    font-size: 10px;"
+        "    font-weight: 600;"
+        "    min-width: 22px;"
+        "    max-height: 20px;"
+        "}"
+        "QPushButton#moveBtn:hover {"
+        "    background: %9;"
+        "    color: %11;"
+        "    border-color: %6;"
+        "}"
+        "QPushButton#moveBtn:disabled {"
+        "    background: %2;"
+        "    color: %5;"
+        "    border-color: %3;"
+        "}"
+        // --- Panel header separator ---
+        "QFrame#panelHeaderLine {"
+        "    background: qlineargradient("
+        "        x1:0, y1:0, x2:1, y2:0,"
+        "        stop:0 %6,"
+        "        stop:0.4 %5,"
+        "        stop:1 transparent"
+        "    );"
+        "    min-height: 1px;"
+        "    max-height: 1px;"
+        "    border: none;"
+        "}"
+        // --- Panel title ---
+        "QLabel#panelTitle {"
+        "    color: %1;"
+        "    font-size: 12px;"
+        "    font-weight: 600;"
+        "    letter-spacing: 1px;"
+        "}"
+        // --- Move-to label ---
+        "QLabel#moveToLabel {"
+        "    color: %7;"
+        "    font-size: 9px;"
+        "    letter-spacing: 1px;"
+        "}"
+        // --- Metric labels ---
+        "QLabel#metricValue {"
+        "    color: %1;"
+        "    font-size: 20px;"
+        "    font-weight: 700;"
+        "    letter-spacing: -0.5px;"
+        "}"
+        "QLabel#metricKey {"
+        "    color: %7;"
+        "    font-size: 9px;"
+        "    font-weight: 600;"
+        "    letter-spacing: 2px;"
+        "}"
+        "QLabel#metricUnit {"
+        "    color: %6;"
+        "    font-size: 12px;"
+        "    font-weight: 600;"
+        "}"
+        // --- Telemetry timestamp ---
+        "QLabel#telemetryTimestamp {"
+        "    color: %7;"
+        "    font-size: 10px;"
+        "}"
+        // --- Telemetry status ---
+        "QLabel#telemetryStatus {"
+        "    color: %8;"
+        "    font-size: 10px;"
+        "    font-style: italic;"
+        "}"
+        // --- Process status ---
+        "QLabel#processStatus {"
+        "    color: %7;"
+        "    font-size: 10px;"
+        "    font-style: italic;"
+        "    padding-bottom: 4px;"
+        "}"
+        // --- Process row labels ---
+        "QLabel#processRow {"
+        "    color: %8;"
+        "    font-family: 'Cascadia Mono', 'Consolas', monospace;"
+        "    font-size: 10px;"
+        "    padding: 3px 6px;"
+        "    border-radius: 3px;"
+        "}"
+        "QLabel#processRowAlt {"
+        "    color: %8;"
+        "    font-family: 'Cascadia Mono', 'Consolas', monospace;"
+        "    font-size: 10px;"
+        "    background: %4;"
+        "    padding: 3px 6px;"
+        "    border-radius: 3px;"
+        "}"
+        // --- Timeline / render status ---
+        "QLabel#timelineStatus {"
+        "    color: %7;"
+        "    font-size: 10px;"
+        "    font-style: italic;"
+        "}"
+        "QLabel#renderStatus {"
+        "    color: %7;"
+        "    font-size: 10px;"
+        "    font-style: italic;"
+        "}"
+        // --- Footer ---
+        "QLabel#footerStatus {"
+        "    color: %12;"
+        "    font-size: 9px;"
+        "    font-family: 'Cascadia Mono', 'Consolas', monospace;"
+        "    padding: 4px 12px 8px 14px;"
+        "    border-left: 2px solid %6;"
+        "    margin-left: 12px;"
+        "    margin-bottom: 4px;"
+        "}"
+        // --- Scrollbars ---
+        "QScrollBar:vertical {"
+        "    background: %2;"
+        "    width: 6px;"
+        "    border-radius: 3px;"
+        "    margin: 0px;"
+        "}"
+        "QScrollBar::handle:vertical {"
+        "    background: %5;"
+        "    border-radius: 3px;"
+        "    min-height: 20px;"
+        "}"
+        "QScrollBar::handle:vertical:hover {"
+        "    background: %12;"
+        "}"
+        "QScrollBar::add-line:vertical, QScrollBar::sub-line:vertical {"
+        "    height: 0px;"
+        "}"
+        "QScrollBar:horizontal {"
+        "    background: %2;"
+        "    height: 6px;"
+        "    border-radius: 3px;"
+        "    margin: 0px;"
+        "}"
+        "QScrollBar::handle:horizontal {"
+        "    background: %5;"
+        "    border-radius: 3px;"
+        "    min-width: 20px;"
+        "}"
+        "QScrollBar::handle:horizontal:hover {"
+        "    background: %12;"
+        "}"
+        "QScrollBar::add-line:horizontal, QScrollBar::sub-line:horizontal {"
+        "    width: 0px;"
+        "}"
+    )
+    .arg(p.text_primary)     // %1
+    .arg(p.bg_window)        // %2
+    .arg(p.bg_surface)       // %3
+    .arg(p.bg_panel)         // %4
+    .arg(p.border_subtle)    // %5
+    .arg(p.accent)           // %6
+    .arg(p.text_muted)       // %7
+    .arg(p.text_secondary)   // %8
+    .arg(p.bg_elevated)      // %9
+    .arg(p.danger)           // %10
+    .arg(p.accent_hover)     // %11
+    .arg(p.border_active);   // %12
 }
 
 // ---------------------------------------------------------------------------
@@ -595,8 +540,19 @@ public:
                 .toStdString()
         );
         setWindowTitle("Aura | Native Shell");
-        setMinimumSize(1100, 640);
         setWindowFlags(Qt::FramelessWindowHint | Qt::Window | Qt::WindowMinMaxButtonsHint);
+
+        // Screen-relative sizing — minimum 55%w / 60%h with floor 900x560
+        if (const QScreen* screen = QApplication::primaryScreen()) {
+            const QRect avail = screen->availableGeometry();
+            const int min_w = std::max(900, static_cast<int>(avail.width() * 0.55));
+            const int min_h = std::max(560, static_cast<int>(avail.height() * 0.60));
+            setMinimumSize(min_w, min_h);
+            resize(static_cast<int>(avail.width() * 0.75),
+                   static_cast<int>(avail.height() * 0.75));
+        } else {
+            setMinimumSize(900, 560);
+        }
         setStyleSheet(build_app_stylesheet(current_theme_mode_));
         current_interval_seconds_ =
             (std::isfinite(config.interval_seconds) && config.interval_seconds > 0.0)
@@ -700,8 +656,11 @@ public:
         auto* body = new QWidget(root);
         body->setAutoFillBackground(false);
         auto* body_layout = new QHBoxLayout(body);
-        body_layout->setContentsMargins(12, 12, 12, 8);
-        body_layout->setSpacing(10);
+        const double dpr = devicePixelRatioF();
+        body_layout->setContentsMargins(
+            static_cast<int>(12 * dpr), static_cast<int>(12 * dpr),
+            static_cast<int>(12 * dpr), static_cast<int>(8 * dpr));
+        body_layout->setSpacing(static_cast<int>(10 * dpr));
 
         for (const auto slot : aura::shell::all_dock_slots()) {
             const std::size_t index = slot_index(slot);
@@ -792,6 +751,7 @@ private:
 
     void apply_theme(const aura::shell::UiThemeMode mode, const bool persist) {
         current_theme_mode_ = mode;
+        theme_dirty_ = true;
         setStyleSheet(build_app_stylesheet(current_theme_mode_));
         if (theme_toggle_btn_ != nullptr) {
             theme_toggle_btn_->setText(QString::fromStdString(aura::shell::ui_theme_mode_label(mode)));
@@ -999,7 +959,7 @@ private:
             quick_ = new QQuickWidget(parent_page);
             quick_->setResizeMode(QQuickWidget::SizeRootObjectToView);
             quick_->setSource(QUrl::fromLocalFile(QStringLiteral(AURA_SHELL_QML_PATH)));
-            quick_->setMinimumHeight(340);
+            quick_->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
 
             render_status_ = new QLabel("Cockpit scene online", parent_page);
             render_status_->setObjectName("renderStatus");
@@ -1192,10 +1152,13 @@ private:
             root->setProperty("qualityHint", state.quality_hint);
             root->setProperty("timelineAnomalyAlpha", state.style_tokens.timeline_anomaly_alpha);
             root->setProperty("statusText", QString::fromStdString(state.status_line));
-            root->setProperty(
-                "themeMode",
-                QString::fromStdString(aura::shell::ui_theme_mode_key(current_theme_mode_))
-            );
+            if (theme_dirty_) {
+                root->setProperty(
+                    "themeMode",
+                    QString::fromStdString(aura::shell::ui_theme_mode_key(current_theme_mode_))
+                );
+                theme_dirty_ = false;
+            }
         }
 
         if (update_timer_ != nullptr) {
@@ -1229,6 +1192,7 @@ private:
     QLabel* render_status_{nullptr};
     QLabel* footer_status_{nullptr};
     std::array<QLabel*, 5> process_labels_{};
+    bool theme_dirty_{true};
     bool dragging_{false};
     QPoint drag_origin_{};
 };
@@ -1236,6 +1200,8 @@ private:
 }  // namespace
 
 int main(int argc, char* argv[]) {
+    QApplication::setHighDpiScaleFactorRoundingPolicy(
+        Qt::HighDpiScaleFactorRoundingPolicy::PassThrough);
     QApplication app(argc, argv);
     app.setApplicationName("Aura");
     app.setApplicationVersion("1.0.0");

--- a/src/shell/native/src/ui_theme.cpp
+++ b/src/shell/native/src/ui_theme.cpp
@@ -2,6 +2,47 @@
 
 namespace aura::shell {
 
+static constexpr ThemePalette kDarkBluePalette{
+    "#060b14",  // bg_window
+    "#0a1221",  // bg_panel
+    "#0f1a2e",  // bg_surface
+    "#162238",  // bg_elevated
+    "#1e3350",  // border_subtle
+    "#2a4a6e",  // border_active
+    "#3b82f6",  // border_accent
+    "#e0ecf7",  // text_primary
+    "#8badc4",  // text_secondary
+    "#4d6d87",  // text_muted
+    "#3b82f6",  // accent
+    "#60a5fa",  // accent_hover
+    "#ef4444",  // danger
+    "#f87171",  // danger_hover
+};
+
+static constexpr ThemePalette kPinkCutePalette{
+    "#150a12",  // bg_window
+    "#1f0e1a",  // bg_panel
+    "#2d1525",  // bg_surface
+    "#3d1d33",  // bg_elevated
+    "#6c2d55",  // border_subtle
+    "#91406f",  // border_active
+    "#ff4da6",  // border_accent
+    "#ffe8f5",  // text_primary
+    "#ffb3d9",  // text_secondary
+    "#d887b1",  // text_muted
+    "#ff4da6",  // accent
+    "#ff92c5",  // accent_hover
+    "#ef4444",  // danger
+    "#f87171",  // danger_hover
+};
+
+const ThemePalette& get_theme_palette(const UiThemeMode mode) {
+    if (mode == UiThemeMode::PinkCute) {
+        return kPinkCutePalette;
+    }
+    return kDarkBluePalette;
+}
+
 UiThemeMode ui_theme_mode_from_key(const std::string_view key) {
     if (key == "pink_cute") {
         return UiThemeMode::PinkCute;


### PR DESCRIPTION
- DPI-aware window sizing with screen-relative minimum (55%w/60%h, floor 900x560)
- ColumnLayout-based QML with proportional spacing, margins, and font sizes
- ThemePalette struct with token-based stylesheet generation (no more string-replace chain)
- Canvas-drawn decorative accents (star, diamond, hearts, dot rail) replacing emoji Text items
- QML color tokens (clrBgDeep, clrAccent, clrTextPrimary, etc.) replacing scattered uiColor calls
- theme_dirty_ flag to skip redundant QML themeMode pushes on every tick
- Gauge size uncapped to 240px with height-based effectiveGaugeSize clamping
- Sparklines use Layout.fillHeight for responsive vertical sizing