### PR TITLE
Add network telemetry fields (net_recv_bps, net_sent_bps) to snapshot

### DIFF
--- a/src/runtime/native/include/aura_platform.h
+++ b/src/runtime/native/include/aura_platform.h
@@ -2,7 +2,7 @@
 
 #include <stddef.h>
 
-#define AURA_PLATFORM_ABI_VERSION 1
+#define AURA_PLATFORM_ABI_VERSION 2
 
 #ifdef _WIN32
 #define AURA_PLATFORM_EXPORT __declspec(dllexport)
@@ -22,6 +22,8 @@ typedef struct aura_snapshot_t {
     double memory_percent;
     double disk_read_bps;
     double disk_write_bps;
+    double net_recv_bps;
+    double net_sent_bps;
 } aura_snapshot_t;
 
 enum aura_db_source_t {

--- a/src/runtime/native/src/c_api.cpp
+++ b/src/runtime/native/src/c_api.cpp
@@ -55,6 +55,8 @@ Snapshot ToInternalSnapshot(const aura_snapshot_t& raw) {
     out.memory_percent = raw.memory_percent;
     out.disk_read_bps = raw.disk_read_bps;
     out.disk_write_bps = raw.disk_write_bps;
+    out.net_recv_bps = raw.net_recv_bps;
+    out.net_sent_bps = raw.net_sent_bps;
     return out;
 }
 
@@ -65,6 +67,8 @@ aura_snapshot_t ToAbiSnapshot(const Snapshot& raw) {
     out.memory_percent = raw.memory_percent;
     out.disk_read_bps = raw.disk_read_bps;
     out.disk_write_bps = raw.disk_write_bps;
+    out.net_recv_bps = raw.net_recv_bps;
+    out.net_sent_bps = raw.net_sent_bps;
     return out;
 }
 

--- a/src/runtime/native/src/dvr_lttb.cpp
+++ b/src/runtime/native/src/dvr_lttb.cpp
@@ -8,7 +8,7 @@ namespace aura::platform {
 
 namespace {
 
-constexpr int kNumFields = 4;
+constexpr int kNumFields = 6;
 constexpr double kRangeEpsilon = 1e-9;
 
 inline double GetField(const Snapshot& s, int field_index) {
@@ -17,6 +17,8 @@ inline double GetField(const Snapshot& s, int field_index) {
         case 1: return s.memory_percent;
         case 2: return s.disk_read_bps;
         case 3: return s.disk_write_bps;
+        case 4: return s.net_recv_bps;
+        case 5: return s.net_sent_bps;
         default: return 0.0;
     }
 }

--- a/src/runtime/native/src/platform_internal.hpp
+++ b/src/runtime/native/src/platform_internal.hpp
@@ -17,6 +17,8 @@ struct Snapshot {
     double memory_percent = 0.0;
     double disk_read_bps = 0.0;
     double disk_write_bps = 0.0;
+    double net_recv_bps = 0.0;
+    double net_sent_bps = 0.0;
 };
 
 enum class DbSource {

--- a/src/runtime/native/src/runtime_cli.cpp
+++ b/src/runtime/native/src/runtime_cli.cpp
@@ -202,6 +202,8 @@ void PrintSnapshot(const aura::platform::Snapshot& snapshot, const bool output_j
             << ", \"memory_percent\": " << std::fixed << std::setprecision(1) << snapshot.memory_percent
             << ", \"disk_read_bps\": " << std::fixed << std::setprecision(1) << snapshot.disk_read_bps
             << ", \"disk_write_bps\": " << std::fixed << std::setprecision(1) << snapshot.disk_write_bps
+            << ", \"net_recv_bps\": " << std::fixed << std::setprecision(1) << snapshot.net_recv_bps
+            << ", \"net_sent_bps\": " << std::fixed << std::setprecision(1) << snapshot.net_sent_bps
             << ", \"timestamp\": " << std::setprecision(3) << snapshot.timestamp
             << "}" << '\n';
         return;
@@ -212,6 +214,8 @@ void PrintSnapshot(const aura::platform::Snapshot& snapshot, const bool output_j
         << "mem=" << std::fixed << std::setprecision(1) << snapshot.memory_percent << "% "
         << "disk_read_bps=" << std::fixed << std::setprecision(1) << snapshot.disk_read_bps << " "
         << "disk_write_bps=" << std::fixed << std::setprecision(1) << snapshot.disk_write_bps << " "
+        << "net_recv_bps=" << std::fixed << std::setprecision(1) << snapshot.net_recv_bps << " "
+        << "net_sent_bps=" << std::fixed << std::setprecision(1) << snapshot.net_sent_bps << " "
         << "ts=" << std::setprecision(3) << snapshot.timestamp
         << '\n';
 }
@@ -265,6 +269,8 @@ std::vector<aura::platform::Snapshot> LoadSnapshots(
         next.memory_percent = output[i].memory_percent;
         next.disk_read_bps = output[i].disk_read_bps;
         next.disk_write_bps = output[i].disk_write_bps;
+        next.net_recv_bps = output[i].net_recv_bps;
+        next.net_sent_bps = output[i].net_sent_bps;
         snapshots.push_back(next);
     }
     return snapshots;
@@ -284,6 +290,8 @@ aura::platform::Snapshot CollectSnapshotViaApi() {
     snapshot.memory_percent = raw.memory_percent;
     snapshot.disk_read_bps = raw.disk_read_bps;
     snapshot.disk_write_bps = raw.disk_write_bps;
+    snapshot.net_recv_bps = raw.net_recv_bps;
+    snapshot.net_sent_bps = raw.net_sent_bps;
     return snapshot;
 }
 
@@ -352,6 +360,8 @@ int main(int argc, char** argv) {
                     raw.memory_percent = snapshot.memory_percent;
                     raw.disk_read_bps = snapshot.disk_read_bps;
                     raw.disk_write_bps = snapshot.disk_write_bps;
+                    raw.net_recv_bps = snapshot.net_recv_bps;
+                    raw.net_sent_bps = snapshot.net_sent_bps;
                     const int rc = aura_store_append(store, &raw, &err);
                     if (rc != AURA_OK) {
                         std::cerr << "DVR persistence disabled: "
@@ -388,6 +398,8 @@ int main(int argc, char** argv) {
             raw.memory_percent = snapshot.memory_percent;
             raw.disk_read_bps = snapshot.disk_read_bps;
             raw.disk_write_bps = snapshot.disk_write_bps;
+            raw.net_recv_bps = snapshot.net_recv_bps;
+            raw.net_sent_bps = snapshot.net_sent_bps;
             const int rc = aura_store_append(store, &raw, &err);
             if (rc != AURA_OK) {
                 std::cerr << "DVR persistence disabled: "

--- a/src/runtime/native/src/store_sqlite.cpp
+++ b/src/runtime/native/src/store_sqlite.cpp
@@ -75,8 +75,6 @@ Snapshot ParseSnapshotLine(const std::string& line) {
     std::string ts_raw;
     std::string cpu_raw;
     std::string mem_raw;
-    std::string disk_read_raw;
-    std::string disk_write_raw;
 
     if (!std::getline(input, ts_raw, ',')) {
         throw std::runtime_error("Malformed snapshot line: missing timestamp");
@@ -86,8 +84,6 @@ Snapshot ParseSnapshotLine(const std::string& line) {
     }
 
     Snapshot out;
-    out.disk_read_bps = 0.0;
-    out.disk_write_bps = 0.0;
 
     if (!std::getline(input, mem_raw, ',')) {
         throw std::runtime_error("Malformed snapshot line: missing memory_percent");
@@ -97,9 +93,18 @@ Snapshot ParseSnapshotLine(const std::string& line) {
     out.cpu_percent = std::stod(cpu_raw);
     out.memory_percent = std::stod(mem_raw);
 
-    if (std::getline(input, disk_read_raw, ',') && std::getline(input, disk_write_raw)) {
+    std::string disk_read_raw;
+    std::string disk_write_raw;
+    if (std::getline(input, disk_read_raw, ',') && std::getline(input, disk_write_raw, ',')) {
         out.disk_read_bps = std::stod(disk_read_raw);
         out.disk_write_bps = std::stod(disk_write_raw);
+
+        std::string net_recv_raw;
+        std::string net_sent_raw;
+        if (std::getline(input, net_recv_raw, ',') && std::getline(input, net_sent_raw)) {
+            out.net_recv_bps = std::stod(net_recv_raw);
+            out.net_sent_bps = std::stod(net_sent_raw);
+        }
     }
 
     ValidateSnapshot(out);
@@ -182,6 +187,8 @@ class SqliteStore final : public TelemetryStore {
         sqlite3_bind_double(stmt_insert_, 3, snapshot.memory_percent);
         sqlite3_bind_double(stmt_insert_, 4, snapshot.disk_read_bps);
         sqlite3_bind_double(stmt_insert_, 5, snapshot.disk_write_bps);
+        sqlite3_bind_double(stmt_insert_, 6, snapshot.net_recv_bps);
+        sqlite3_bind_double(stmt_insert_, 7, snapshot.net_sent_bps);
 
         const int rc = sqlite3_step(stmt_insert_);
         SqliteCheck(db_, rc, "insert snapshot");
@@ -229,6 +236,8 @@ class SqliteStore final : public TelemetryStore {
             s.memory_percent = sqlite3_column_double(stmt_latest_, 2);
             s.disk_read_bps = sqlite3_column_double(stmt_latest_, 3);
             s.disk_write_bps = sqlite3_column_double(stmt_latest_, 4);
+            s.net_recv_bps = sqlite3_column_double(stmt_latest_, 5);
+            s.net_sent_bps = sqlite3_column_double(stmt_latest_, 6);
             results.push_back(s);
         }
 
@@ -272,6 +281,8 @@ class SqliteStore final : public TelemetryStore {
                 s.memory_percent = sqlite3_column_double(stmt_between_, 2);
                 s.disk_read_bps = sqlite3_column_double(stmt_between_, 3);
                 s.disk_write_bps = sqlite3_column_double(stmt_between_, 4);
+                s.net_recv_bps = sqlite3_column_double(stmt_between_, 5);
+                s.net_sent_bps = sqlite3_column_double(stmt_between_, 6);
                 results.push_back(s);
             }
             return results;
@@ -299,6 +310,8 @@ class SqliteStore final : public TelemetryStore {
             s.memory_percent = sqlite3_column_double(stmt_between_, 2);
             s.disk_read_bps = sqlite3_column_double(stmt_between_, 3);
             s.disk_write_bps = sqlite3_column_double(stmt_between_, 4);
+            s.net_recv_bps = sqlite3_column_double(stmt_between_, 5);
+            s.net_sent_bps = sqlite3_column_double(stmt_between_, 6);
             results.push_back(s);
         }
         return results;
@@ -334,7 +347,9 @@ class SqliteStore final : public TelemetryStore {
                 "cpu REAL NOT NULL,"
                 "mem REAL NOT NULL,"
                 "disk_r REAL NOT NULL DEFAULT 0,"
-                "disk_w REAL NOT NULL DEFAULT 0"
+                "disk_w REAL NOT NULL DEFAULT 0,"
+                "net_r REAL NOT NULL DEFAULT 0,"
+                "net_w REAL NOT NULL DEFAULT 0"
                 ");") ||
             !try_exec("CREATE INDEX IF NOT EXISTS idx_snapshots_ts ON snapshots(ts);")) {
             sqlite3_close(db_);
@@ -342,14 +357,21 @@ class SqliteStore final : public TelemetryStore {
             return;
         }
 
+        // Migrate existing databases: add net columns if missing.
+        // Errors are expected and ignored (column may already exist).
+        sqlite3_exec(db_, "ALTER TABLE snapshots ADD COLUMN net_r REAL NOT NULL DEFAULT 0;",
+                     nullptr, nullptr, nullptr);
+        sqlite3_exec(db_, "ALTER TABLE snapshots ADD COLUMN net_w REAL NOT NULL DEFAULT 0;",
+                     nullptr, nullptr, nullptr);
+
         stmt_insert_ = PrepareStatement(db_,
-            "INSERT INTO snapshots(ts,cpu,mem,disk_r,disk_w) VALUES(?,?,?,?,?)");
+            "INSERT INTO snapshots(ts,cpu,mem,disk_r,disk_w,net_r,net_w) VALUES(?,?,?,?,?,?,?)");
         stmt_latest_ = PrepareStatement(db_,
-            "SELECT ts,cpu,mem,disk_r,disk_w FROM snapshots ORDER BY ts DESC LIMIT ?");
+            "SELECT ts,cpu,mem,disk_r,disk_w,net_r,net_w FROM snapshots ORDER BY ts DESC LIMIT ?");
         stmt_count_ = PrepareStatement(db_,
             "SELECT COUNT(*) FROM snapshots");
         stmt_between_ = PrepareStatement(db_,
-            "SELECT ts,cpu,mem,disk_r,disk_w FROM snapshots WHERE ts BETWEEN ? AND ? ORDER BY ts");
+            "SELECT ts,cpu,mem,disk_r,disk_w,net_r,net_w FROM snapshots WHERE ts BETWEEN ? AND ? ORDER BY ts");
         stmt_prune_ = PrepareStatement(db_,
             "DELETE FROM snapshots WHERE ts < ?");
     }
@@ -435,7 +457,9 @@ class SqliteStore final : public TelemetryStore {
             "cpu REAL NOT NULL,"
             "mem REAL NOT NULL,"
             "disk_r REAL NOT NULL DEFAULT 0,"
-            "disk_w REAL NOT NULL DEFAULT 0"
+            "disk_w REAL NOT NULL DEFAULT 0,"
+            "net_r REAL NOT NULL DEFAULT 0,"
+            "net_w REAL NOT NULL DEFAULT 0"
             ");", nullptr, nullptr, nullptr);
         sqlite3_exec(mig_db, "CREATE INDEX IF NOT EXISTS idx_snapshots_ts ON snapshots(ts);",
             nullptr, nullptr, nullptr);
@@ -443,7 +467,7 @@ class SqliteStore final : public TelemetryStore {
         if (!loaded.empty()) {
             sqlite3_exec(mig_db, "BEGIN TRANSACTION;", nullptr, nullptr, nullptr);
             sqlite3_stmt* ins = PrepareStatement(mig_db,
-                "INSERT INTO snapshots(ts,cpu,mem,disk_r,disk_w) VALUES(?,?,?,?,?)");
+                "INSERT INTO snapshots(ts,cpu,mem,disk_r,disk_w,net_r,net_w) VALUES(?,?,?,?,?,?,?)");
             for (const auto& s : loaded) {
                 sqlite3_reset(ins);
                 sqlite3_bind_double(ins, 1, s.timestamp);
@@ -451,6 +475,8 @@ class SqliteStore final : public TelemetryStore {
                 sqlite3_bind_double(ins, 3, s.memory_percent);
                 sqlite3_bind_double(ins, 4, s.disk_read_bps);
                 sqlite3_bind_double(ins, 5, s.disk_write_bps);
+                sqlite3_bind_double(ins, 6, s.net_recv_bps);
+                sqlite3_bind_double(ins, 7, s.net_sent_bps);
                 sqlite3_step(ins);
             }
             sqlite3_finalize(ins);
@@ -488,6 +514,8 @@ void ValidateSnapshot(const Snapshot& snapshot) {
     ValidateFinite(snapshot.memory_percent, "memory_percent");
     ValidateFinite(snapshot.disk_read_bps, "disk_read_bps");
     ValidateFinite(snapshot.disk_write_bps, "disk_write_bps");
+    ValidateFinite(snapshot.net_recv_bps, "net_recv_bps");
+    ValidateFinite(snapshot.net_sent_bps, "net_sent_bps");
 
     if (snapshot.cpu_percent < 0.0 || snapshot.cpu_percent > 100.0) {
         throw std::runtime_error("cpu_percent must be between 0 and 100.");
@@ -500,6 +528,12 @@ void ValidateSnapshot(const Snapshot& snapshot) {
     }
     if (snapshot.disk_write_bps < 0.0) {
         throw std::runtime_error("disk_write_bps must be non-negative.");
+    }
+    if (snapshot.net_recv_bps < 0.0) {
+        throw std::runtime_error("net_recv_bps must be non-negative.");
+    }
+    if (snapshot.net_sent_bps < 0.0) {
+        throw std::runtime_error("net_sent_bps must be non-negative.");
     }
 }
 

--- a/tests/test_platform/native/CMakeLists.txt
+++ b/tests/test_platform/native/CMakeLists.txt
@@ -62,6 +62,26 @@ set_tests_properties(
 )
 
 add_test(
+    NAME platform_cli_json_includes_net_fields
+    COMMAND $<TARGET_FILE:aura> --json --no-persist
+)
+set_tests_properties(
+    platform_cli_json_includes_net_fields
+    PROPERTIES
+        PASS_REGULAR_EXPRESSION "\"net_recv_bps\".*\"net_sent_bps\""
+)
+
+add_test(
+    NAME platform_cli_text_includes_net_fields
+    COMMAND $<TARGET_FILE:aura> --no-persist
+)
+set_tests_properties(
+    platform_cli_text_includes_net_fields
+    PROPERTIES
+        PASS_REGULAR_EXPRESSION "net_recv_bps=.*net_sent_bps="
+)
+
+add_test(
     NAME platform_cli_latest_preserves_disk_fields
     COMMAND powershell -NoProfile -ExecutionPolicy Bypass -File
         ${CMAKE_CURRENT_SOURCE_DIR}/../cli_latest_disk_fields_test.ps1

--- a/tests/test_platform/native/test_platform_dvr.cpp
+++ b/tests/test_platform/native/test_platform_dvr.cpp
@@ -892,3 +892,191 @@ void TestQueryTimelineResolutionOne() {
     rc = aura_store_close(store);
     ExpectEq(rc, AURA_OK, "resolution 1: store close");
 }
+
+// ---------------------------------------------------------------------------
+// Category F: LTTB with Network Telemetry Fields
+// ---------------------------------------------------------------------------
+
+void TestLttbNetRecvSpikePreserved() {
+    const int N = 20;
+    const int spike_index = 10;
+    std::vector<aura_snapshot_t> input;
+    input.reserve(N);
+    for (int i = 0; i < N; ++i) {
+        aura_snapshot_t s{};
+        s.timestamp = 100.0 + static_cast<double>(i);
+        s.cpu_percent = 50.0;
+        s.memory_percent = 40.0;
+        if (i == spike_index) {
+            s.net_recv_bps = 10000000.0;
+        }
+        input.push_back(s);
+    }
+
+    aura_snapshot_t output[5]{};
+    int out_count = 0;
+    aura_error_t error{};
+    const int rc = aura_dvr_downsample_lttb(
+        input.data(), N, 5, output, 5, &out_count, &error
+    );
+    ExpectEq(rc, AURA_OK, "net recv spike: downsample should succeed");
+    ExpectEq(out_count, 5, "net recv spike: output count");
+
+    bool spike_found = false;
+    for (int i = 0; i < out_count; ++i) {
+        if (output[i].net_recv_bps > 5000000.0) {
+            spike_found = true;
+        }
+    }
+    ExpectTrue(spike_found, "net recv spike: net_recv_bps spike must be preserved in output");
+}
+
+void TestLttbNetSentSpikePreserved() {
+    const int N = 20;
+    const int spike_index = 10;
+    std::vector<aura_snapshot_t> input;
+    input.reserve(N);
+    for (int i = 0; i < N; ++i) {
+        aura_snapshot_t s{};
+        s.timestamp = 100.0 + static_cast<double>(i);
+        s.cpu_percent = 50.0;
+        s.memory_percent = 40.0;
+        if (i == spike_index) {
+            s.net_sent_bps = 10000000.0;
+        }
+        input.push_back(s);
+    }
+
+    aura_snapshot_t output[5]{};
+    int out_count = 0;
+    aura_error_t error{};
+    const int rc = aura_dvr_downsample_lttb(
+        input.data(), N, 5, output, 5, &out_count, &error
+    );
+    ExpectEq(rc, AURA_OK, "net sent spike: downsample should succeed");
+    ExpectEq(out_count, 5, "net sent spike: output count");
+
+    bool spike_found = false;
+    for (int i = 0; i < out_count; ++i) {
+        if (output[i].net_sent_bps > 5000000.0) {
+            spike_found = true;
+        }
+    }
+    ExpectTrue(spike_found, "net sent spike: net_sent_bps spike must be preserved in output");
+}
+
+void TestLttbPreservesAllFieldsIncludingNet() {
+    const int N = 15;
+    std::vector<aura_snapshot_t> input;
+    input.reserve(N);
+    for (int i = 0; i < N; ++i) {
+        aura_snapshot_t s{};
+        s.timestamp = 100.0 + static_cast<double>(i);
+        s.cpu_percent = static_cast<double>(i);
+        s.memory_percent = 50.0 + static_cast<double>(i) * 0.5;
+        s.disk_read_bps = 1000.0 * static_cast<double>(i);
+        s.disk_write_bps = 2000.0 * static_cast<double>(i);
+        s.net_recv_bps = 10000.0 * static_cast<double>(i);
+        s.net_sent_bps = 5000.0 * static_cast<double>(i);
+        input.push_back(s);
+    }
+
+    aura_snapshot_t output[5]{};
+    int out_count = 0;
+    aura_error_t error{};
+    const int rc = aura_dvr_downsample_lttb(
+        input.data(), N, 5, output, 5, &out_count, &error
+    );
+    ExpectEq(rc, AURA_OK, "all fields net: should succeed");
+    ExpectEq(out_count, 5, "all fields net: output count");
+
+    for (int i = 0; i < out_count; ++i) {
+        bool found = false;
+        for (int j = 0; j < N; ++j) {
+            if (std::fabs(output[i].timestamp - input[j].timestamp) < 1e-12 &&
+                std::fabs(output[i].cpu_percent - input[j].cpu_percent) < 1e-12 &&
+                std::fabs(output[i].memory_percent - input[j].memory_percent) < 1e-12 &&
+                std::fabs(output[i].disk_read_bps - input[j].disk_read_bps) < 1e-12 &&
+                std::fabs(output[i].disk_write_bps - input[j].disk_write_bps) < 1e-12 &&
+                std::fabs(output[i].net_recv_bps - input[j].net_recv_bps) < 1e-12 &&
+                std::fabs(output[i].net_sent_bps - input[j].net_sent_bps) < 1e-12) {
+                found = true;
+                break;
+            }
+        }
+        ExpectTrue(found, "all fields net: output[" + std::to_string(i) + "] must match input exactly (including net)");
+    }
+}
+
+void TestLttbNetFieldsZeroRangeSkipped() {
+    // Net fields are zero for all input — LTTB should still work
+    // (zero range fields are skipped in area calculation)
+    const int N = 20;
+    std::vector<aura_snapshot_t> input;
+    input.reserve(N);
+    for (int i = 0; i < N; ++i) {
+        aura_snapshot_t s{};
+        s.timestamp = 100.0 + static_cast<double>(i);
+        s.cpu_percent = static_cast<double>(i * 5);
+        s.memory_percent = 50.0;
+        // net fields default to 0.0
+        input.push_back(s);
+    }
+
+    aura_snapshot_t output[5]{};
+    int out_count = 0;
+    aura_error_t error{};
+    const int rc = aura_dvr_downsample_lttb(
+        input.data(), N, 5, output, 5, &out_count, &error
+    );
+    ExpectEq(rc, AURA_OK, "net zero range: should succeed");
+    ExpectEq(out_count, 5, "net zero range: output count");
+    ExpectNear(output[0].timestamp, 100.0, 1e-9, "net zero range: first timestamp");
+    ExpectNear(output[4].timestamp, 119.0, 1e-9, "net zero range: last timestamp");
+
+    // All net fields should be zero
+    for (int i = 0; i < out_count; ++i) {
+        ExpectNear(output[i].net_recv_bps, 0.0, 1e-9,
+                   "net zero range: net_recv[" + std::to_string(i) + "] zero");
+        ExpectNear(output[i].net_sent_bps, 0.0, 1e-9,
+                   "net zero range: net_sent[" + std::to_string(i) + "] zero");
+    }
+}
+
+void TestLttbSixFieldNormalizationNetVsCpu() {
+    // CPU varies 0-100, net_recv_bps varies 0-1e9.
+    // Both have significant spikes. Normalization should preserve both.
+    const int N = 30;
+    std::vector<aura_snapshot_t> input;
+    input.reserve(N);
+    for (int i = 0; i < N; ++i) {
+        aura_snapshot_t s{};
+        s.timestamp = 100.0 + static_cast<double>(i);
+        s.cpu_percent = 50.0;
+        s.memory_percent = 40.0;
+        s.net_recv_bps = 500000000.0;
+        input.push_back(s);
+    }
+    // CPU spike at index 8
+    input[8].cpu_percent = 95.0;
+    // Net recv spike at index 22
+    input[22].net_recv_bps = 950000000.0;
+
+    aura_snapshot_t output[8]{};
+    int out_count = 0;
+    aura_error_t error{};
+    const int rc = aura_dvr_downsample_lttb(
+        input.data(), N, 8, output, 8, &out_count, &error
+    );
+    ExpectEq(rc, AURA_OK, "net normalization: should succeed");
+    ExpectEq(out_count, 8, "net normalization: output count");
+
+    bool cpu_spike_found = false;
+    bool net_spike_found = false;
+    for (int i = 0; i < out_count; ++i) {
+        if (output[i].cpu_percent > 80.0) cpu_spike_found = true;
+        if (output[i].net_recv_bps > 800000000.0) net_spike_found = true;
+    }
+    ExpectTrue(cpu_spike_found, "net normalization: CPU spike should be preserved");
+    ExpectTrue(net_spike_found, "net normalization: net_recv spike should be preserved");
+}

--- a/tests/test_platform/native/test_platform_helpers.hpp
+++ b/tests/test_platform/native/test_platform_helpers.hpp
@@ -148,6 +148,23 @@ inline std::string SnapshotLineWithDisk(
     return output.str();
 }
 
+inline std::string SnapshotLineWithNet(
+    const double timestamp,
+    const double cpu_percent,
+    const double memory_percent,
+    const double disk_read_bps,
+    const double disk_write_bps,
+    const double net_recv_bps,
+    const double net_sent_bps
+) {
+    std::ostringstream output;
+    output.precision(17);
+    output << timestamp << ',' << cpu_percent << ',' << memory_percent
+           << ',' << disk_read_bps << ',' << disk_write_bps
+           << ',' << net_recv_bps << ',' << net_sent_bps;
+    return output.str();
+}
+
 inline void WriteTextFileLines(const std::filesystem::path& path, const std::vector<std::string>& lines) {
     std::ofstream output(path, std::ios::trunc | std::ios::binary);
     if (!output.is_open()) {

--- a/tests/test_platform/native/test_platform_native.cpp
+++ b/tests/test_platform/native/test_platform_native.cpp
@@ -237,7 +237,7 @@ void TestSqliteConcurrentReadWrite() {
 }
 
 // ---------------------------------------------------------------------------
-// main — calls all 47 tests
+// main — calls all 66 tests
 // ---------------------------------------------------------------------------
 
 int main() {
@@ -309,6 +309,35 @@ int main() {
 
     // Concurrency test (1)
     TestSqliteConcurrentReadWrite();
+
+    // Network field store persistence tests (4)
+    TestSnapshotNetFieldsPersisted();
+    TestSnapshotNetFieldsPersistedToFile();
+    TestSnapshotNetFieldsDefaultToZero();
+    TestSnapshotNetFieldsInBetweenQuery();
+
+    // Schema migration tests (5)
+    TestSchemaMigrationAddsNetColumns();
+    TestSchemaMigrationIdempotent();
+    TestCsvMigration7FieldLines();
+    TestCsvMigration5FieldLinesNetDefaultZero();
+    TestCsvMigrationMixed5And7FieldLines();
+
+    // DVR tests — LTTB with network fields (5)
+    TestLttbNetRecvSpikePreserved();
+    TestLttbNetSentSpikePreserved();
+    TestLttbPreservesAllFieldsIncludingNet();
+    TestLttbNetFieldsZeroRangeSkipped();
+    TestLttbSixFieldNormalizationNetVsCpu();
+
+    // Validation tests — network fields (3)
+    TestValidateSnapshotRejectsNegativeNetRecv();
+    TestValidateSnapshotRejectsNegativeNetSent();
+    TestValidateSnapshotRejectsInfiniteNetRecv();
+
+    // C API round-trip tests — network fields (2)
+    TestAbiSnapshotNetFieldsRoundTrip();
+    TestAbiSnapshotNetFieldsZeroInit();
 
     std::cout << "platform_native_tests: PASS" << std::endl;
     return 0;

--- a/tests/test_platform/native/test_platform_store.cpp
+++ b/tests/test_platform/native/test_platform_store.cpp
@@ -243,3 +243,441 @@ void TestCorruptLineToleranceDoesNotCrash() {
 
     CleanupStoreFiles(db_path);
 }
+
+// ---------------------------------------------------------------------------
+// Network telemetry field tests — store persistence
+// ---------------------------------------------------------------------------
+
+void TestSnapshotNetFieldsPersisted() {
+    aura_error_t error{};
+    aura_store_t* store = nullptr;
+
+    int rc = aura_store_open(":memory:", 3600.0, &store, &error);
+    ExpectEq(rc, AURA_OK, "net fields: store open should succeed");
+
+    const double base = NowSeconds();
+    aura_snapshot_t snap{};
+    snap.timestamp = base;
+    snap.cpu_percent = 10.0;
+    snap.memory_percent = 20.0;
+    snap.disk_read_bps = 100.0;
+    snap.disk_write_bps = 200.0;
+    snap.net_recv_bps = 5000000.0;
+    snap.net_sent_bps = 3000000.0;
+
+    rc = aura_store_append(store, &snap, &error);
+    ExpectEq(rc, AURA_OK, "net fields: append should succeed");
+
+    aura_snapshot_t latest[1]{};
+    int out_count = 0;
+    rc = aura_store_latest(store, 1, latest, 1, &out_count, &error);
+    ExpectEq(rc, AURA_OK, "net fields: latest should succeed");
+    ExpectEq(out_count, 1, "net fields: latest count should be one");
+    ExpectNear(latest[0].net_recv_bps, 5000000.0, 1e-3, "net_recv_bps should persist");
+    ExpectNear(latest[0].net_sent_bps, 3000000.0, 1e-3, "net_sent_bps should persist");
+    ExpectNear(latest[0].cpu_percent, 10.0, 1e-3, "net fields: cpu_percent preserved");
+    ExpectNear(latest[0].disk_read_bps, 100.0, 1e-3, "net fields: disk_read_bps preserved");
+
+    rc = aura_store_close(store);
+    ExpectEq(rc, AURA_OK, "net fields: store close");
+}
+
+void TestSnapshotNetFieldsPersistedToFile() {
+    const std::filesystem::path db_path = BuildStorePath("net_fields_file");
+    const std::string db_path_raw = db_path.string();
+
+    aura_error_t error{};
+    aura_store_t* store = nullptr;
+    int rc = aura_store_open(db_path_raw.c_str(), 3600.0, &store, &error);
+    ExpectEq(rc, AURA_OK, "net fields file: store open should succeed");
+
+    const double base = NowSeconds() - 10.0;
+    aura_snapshot_t snap{};
+    snap.timestamp = base;
+    snap.cpu_percent = 15.0;
+    snap.memory_percent = 25.0;
+    snap.disk_read_bps = 500000.0;
+    snap.disk_write_bps = 300000.0;
+    snap.net_recv_bps = 8000000.0;
+    snap.net_sent_bps = 4000000.0;
+
+    rc = aura_store_append(store, &snap, &error);
+    ExpectEq(rc, AURA_OK, "net fields file: append should succeed");
+
+    rc = aura_store_close(store);
+    ExpectEq(rc, AURA_OK, "net fields file: close first handle");
+
+    store = nullptr;
+    rc = aura_store_open(db_path_raw.c_str(), 3600.0, &store, &error);
+    ExpectEq(rc, AURA_OK, "net fields file: reopen should succeed");
+
+    aura_snapshot_t latest[1]{};
+    int out_count = 0;
+    rc = aura_store_latest(store, 1, latest, 1, &out_count, &error);
+    ExpectEq(rc, AURA_OK, "net fields file: latest should succeed");
+    ExpectEq(out_count, 1, "net fields file: latest count should be one");
+    ExpectNear(latest[0].net_recv_bps, 8000000.0, 1e-3, "net_recv_bps should persist across reopen");
+    ExpectNear(latest[0].net_sent_bps, 4000000.0, 1e-3, "net_sent_bps should persist across reopen");
+
+    rc = aura_store_close(store);
+    ExpectEq(rc, AURA_OK, "net fields file: close second handle");
+
+    CleanupStoreFiles(db_path);
+}
+
+void TestSnapshotNetFieldsDefaultToZero() {
+    aura_error_t error{};
+    aura_store_t* store = nullptr;
+
+    int rc = aura_store_open(":memory:", 3600.0, &store, &error);
+    ExpectEq(rc, AURA_OK, "net default: store open");
+
+    const double base = NowSeconds();
+    aura_snapshot_t snap{base, 10.0, 20.0};
+
+    rc = aura_store_append(store, &snap, &error);
+    ExpectEq(rc, AURA_OK, "net default: append");
+
+    aura_snapshot_t latest[1]{};
+    int out_count = 0;
+    rc = aura_store_latest(store, 1, latest, 1, &out_count, &error);
+    ExpectEq(rc, AURA_OK, "net default: latest");
+    ExpectEq(out_count, 1, "net default: count");
+    ExpectNear(latest[0].net_recv_bps, 0.0, 1e-9, "net_recv_bps defaults to zero");
+    ExpectNear(latest[0].net_sent_bps, 0.0, 1e-9, "net_sent_bps defaults to zero");
+
+    aura_store_close(store);
+}
+
+void TestSnapshotNetFieldsInBetweenQuery() {
+    aura_error_t error{};
+    aura_store_t* store = nullptr;
+
+    int rc = aura_store_open(":memory:", 3600.0, &store, &error);
+    ExpectEq(rc, AURA_OK, "net between: store open");
+
+    const double base = NowSeconds();
+    aura_snapshot_t snap1{};
+    snap1.timestamp = base;
+    snap1.cpu_percent = 10.0;
+    snap1.memory_percent = 20.0;
+    snap1.net_recv_bps = 1000000.0;
+    snap1.net_sent_bps = 500000.0;
+
+    aura_snapshot_t snap2{};
+    snap2.timestamp = base + 1.0;
+    snap2.cpu_percent = 11.0;
+    snap2.memory_percent = 21.0;
+    snap2.net_recv_bps = 2000000.0;
+    snap2.net_sent_bps = 600000.0;
+
+    rc = aura_store_append(store, &snap1, &error);
+    ExpectEq(rc, AURA_OK, "net between: append first");
+    rc = aura_store_append(store, &snap2, &error);
+    ExpectEq(rc, AURA_OK, "net between: append second");
+
+    aura_snapshot_t range[2]{};
+    int out_count = 0;
+    rc = aura_store_between(store, 1, base - 0.5, 1, base + 1.5, range, 2, &out_count, &error);
+    ExpectEq(rc, AURA_OK, "net between: query should succeed");
+    ExpectEq(out_count, 2, "net between: count should be two");
+    ExpectNear(range[0].net_recv_bps, 1000000.0, 1e-3, "net between: first net_recv_bps");
+    ExpectNear(range[1].net_recv_bps, 2000000.0, 1e-3, "net between: second net_recv_bps");
+    ExpectNear(range[1].net_sent_bps, 600000.0, 1e-3, "net between: second net_sent_bps");
+
+    aura_store_close(store);
+}
+
+// ---------------------------------------------------------------------------
+// Network telemetry field tests — schema migration
+// ---------------------------------------------------------------------------
+
+void TestSchemaMigrationAddsNetColumns() {
+    const std::filesystem::path db_path = BuildStorePath("schema_migration_net");
+    const std::string db_path_raw = db_path.string();
+    const double base = NowSeconds() - 10.0;
+
+    WriteTextFileLines(db_path, {
+        SnapshotLineWithDisk(base, 50.0, 60.0, 1000.0, 2000.0),
+    });
+
+    aura_error_t error{};
+    aura_store_t* store = nullptr;
+    int rc = aura_store_open(db_path_raw.c_str(), 3600.0, &store, &error);
+    ExpectEq(rc, AURA_OK, "schema migration: store open");
+
+    aura_snapshot_t latest[1]{};
+    int out_count = 0;
+    rc = aura_store_latest(store, 1, latest, 1, &out_count, &error);
+    ExpectEq(rc, AURA_OK, "schema migration: latest");
+    ExpectEq(out_count, 1, "schema migration: count");
+    ExpectNear(latest[0].cpu_percent, 50.0, 1e-3, "schema migration: cpu preserved");
+    ExpectNear(latest[0].net_recv_bps, 0.0, 1e-9, "migrated row: net_recv_bps defaults to zero");
+    ExpectNear(latest[0].net_sent_bps, 0.0, 1e-9, "migrated row: net_sent_bps defaults to zero");
+
+    aura_snapshot_t new_snap{};
+    new_snap.timestamp = base + 1.0;
+    new_snap.cpu_percent = 55.0;
+    new_snap.memory_percent = 65.0;
+    new_snap.net_recv_bps = 7000000.0;
+    new_snap.net_sent_bps = 3500000.0;
+    rc = aura_store_append(store, &new_snap, &error);
+    ExpectEq(rc, AURA_OK, "schema migration: append new row");
+
+    aura_snapshot_t all[2]{};
+    out_count = 0;
+    rc = aura_store_latest(store, 2, all, 2, &out_count, &error);
+    ExpectEq(rc, AURA_OK, "schema migration: latest after new row");
+    ExpectEq(out_count, 2, "schema migration: count after new row");
+    ExpectNear(all[0].net_recv_bps, 0.0, 1e-9, "old row net_recv still zero");
+    ExpectNear(all[1].net_recv_bps, 7000000.0, 1e-3, "new row net_recv set");
+
+    aura_store_close(store);
+    CleanupStoreFiles(db_path);
+}
+
+void TestSchemaMigrationIdempotent() {
+    const std::filesystem::path db_path = BuildStorePath("schema_idempotent");
+    const std::string db_path_raw = db_path.string();
+
+    aura_error_t error{};
+    aura_store_t* store = nullptr;
+
+    int rc = aura_store_open(db_path_raw.c_str(), 3600.0, &store, &error);
+    ExpectEq(rc, AURA_OK, "idempotent: first open");
+
+    const double base = NowSeconds() - 10.0;
+    aura_snapshot_t snap{};
+    snap.timestamp = base;
+    snap.cpu_percent = 10.0;
+    snap.memory_percent = 20.0;
+    snap.net_recv_bps = 1000000.0;
+    snap.net_sent_bps = 500000.0;
+    rc = aura_store_append(store, &snap, &error);
+    ExpectEq(rc, AURA_OK, "idempotent: append");
+
+    rc = aura_store_close(store);
+    ExpectEq(rc, AURA_OK, "idempotent: first close");
+
+    store = nullptr;
+    rc = aura_store_open(db_path_raw.c_str(), 3600.0, &store, &error);
+    ExpectEq(rc, AURA_OK, "idempotent: second open should succeed");
+
+    aura_snapshot_t latest[1]{};
+    int out_count = 0;
+    rc = aura_store_latest(store, 1, latest, 1, &out_count, &error);
+    ExpectEq(rc, AURA_OK, "idempotent: latest after reopen");
+    ExpectEq(out_count, 1, "idempotent: count");
+    ExpectNear(latest[0].net_recv_bps, 1000000.0, 1e-3, "idempotent: net_recv preserved");
+
+    aura_store_close(store);
+    CleanupStoreFiles(db_path);
+}
+
+void TestCsvMigration7FieldLines() {
+    const std::filesystem::path db_path = BuildStorePath("csv_7field");
+    const std::string db_path_raw = db_path.string();
+    const double base = NowSeconds() - 10.0;
+
+    WriteTextFileLines(db_path, {
+        SnapshotLineWithNet(base, 50.0, 60.0, 1000.0, 2000.0, 5000000.0, 3000000.0),
+    });
+
+    aura_error_t error{};
+    aura_store_t* store = nullptr;
+    int rc = aura_store_open(db_path_raw.c_str(), 3600.0, &store, &error);
+    ExpectEq(rc, AURA_OK, "7-field CSV: store open");
+
+    aura_snapshot_t latest[1]{};
+    int out_count = 0;
+    rc = aura_store_latest(store, 1, latest, 1, &out_count, &error);
+    ExpectEq(rc, AURA_OK, "7-field CSV: latest");
+    ExpectEq(out_count, 1, "7-field CSV: count");
+    ExpectNear(latest[0].cpu_percent, 50.0, 1e-3, "7-field CSV: cpu parsed");
+    ExpectNear(latest[0].disk_read_bps, 1000.0, 1e-3, "7-field CSV: disk_read parsed");
+    ExpectNear(latest[0].net_recv_bps, 5000000.0, 1e-3, "7-field CSV: net_recv_bps parsed");
+    ExpectNear(latest[0].net_sent_bps, 3000000.0, 1e-3, "7-field CSV: net_sent_bps parsed");
+
+    aura_store_close(store);
+    CleanupStoreFiles(db_path);
+}
+
+void TestCsvMigration5FieldLinesNetDefaultZero() {
+    const std::filesystem::path db_path = BuildStorePath("csv_5field_net");
+    const std::string db_path_raw = db_path.string();
+    const double base = NowSeconds() - 10.0;
+
+    WriteTextFileLines(db_path, {
+        SnapshotLineWithDisk(base, 40.0, 50.0, 2000.0, 3000.0),
+    });
+
+    aura_error_t error{};
+    aura_store_t* store = nullptr;
+    int rc = aura_store_open(db_path_raw.c_str(), 3600.0, &store, &error);
+    ExpectEq(rc, AURA_OK, "5-field CSV net: store open");
+
+    aura_snapshot_t latest[1]{};
+    int out_count = 0;
+    rc = aura_store_latest(store, 1, latest, 1, &out_count, &error);
+    ExpectEq(rc, AURA_OK, "5-field CSV net: latest");
+    ExpectEq(out_count, 1, "5-field CSV net: count");
+    ExpectNear(latest[0].disk_read_bps, 2000.0, 1e-3, "5-field CSV net: disk_read preserved");
+    ExpectNear(latest[0].net_recv_bps, 0.0, 1e-9, "5-field CSV net: net_recv defaults to zero");
+    ExpectNear(latest[0].net_sent_bps, 0.0, 1e-9, "5-field CSV net: net_sent defaults to zero");
+
+    aura_store_close(store);
+    CleanupStoreFiles(db_path);
+}
+
+void TestCsvMigrationMixed5And7FieldLines() {
+    const std::filesystem::path db_path = BuildStorePath("csv_mixed");
+    const std::string db_path_raw = db_path.string();
+    const double base = NowSeconds() - 10.0;
+
+    WriteTextFileLines(db_path, {
+        SnapshotLineWithDisk(base, 50.0, 60.0, 1000.0, 2000.0),
+        SnapshotLineWithNet(base + 1.0, 55.0, 65.0, 1100.0, 2100.0, 5000000.0, 3000000.0),
+    });
+
+    aura_error_t error{};
+    aura_store_t* store = nullptr;
+    int rc = aura_store_open(db_path_raw.c_str(), 3600.0, &store, &error);
+    ExpectEq(rc, AURA_OK, "mixed CSV: store open");
+
+    aura_snapshot_t latest[2]{};
+    int out_count = 0;
+    rc = aura_store_latest(store, 2, latest, 2, &out_count, &error);
+    ExpectEq(rc, AURA_OK, "mixed CSV: latest");
+    ExpectEq(out_count, 2, "mixed CSV: count");
+    ExpectNear(latest[0].net_recv_bps, 0.0, 1e-9, "mixed CSV: 5-field row net_recv=0");
+    ExpectNear(latest[0].net_sent_bps, 0.0, 1e-9, "mixed CSV: 5-field row net_sent=0");
+    ExpectNear(latest[1].net_recv_bps, 5000000.0, 1e-3, "mixed CSV: 7-field row net_recv parsed");
+    ExpectNear(latest[1].net_sent_bps, 3000000.0, 1e-3, "mixed CSV: 7-field row net_sent parsed");
+
+    aura_store_close(store);
+    CleanupStoreFiles(db_path);
+}
+
+// ---------------------------------------------------------------------------
+// Network telemetry field tests — validation
+// ---------------------------------------------------------------------------
+
+void TestValidateSnapshotRejectsNegativeNetRecv() {
+    aura_error_t error{};
+    aura_store_t* store = nullptr;
+    int rc = aura_store_open(":memory:", 3600.0, &store, &error);
+    ExpectEq(rc, AURA_OK, "neg net_recv: store open");
+
+    aura_snapshot_t snap{};
+    snap.timestamp = NowSeconds();
+    snap.cpu_percent = 10.0;
+    snap.memory_percent = 20.0;
+    snap.net_recv_bps = -1.0;
+
+    rc = aura_store_append(store, &snap, &error);
+    ExpectTrue(rc != AURA_OK, "negative net_recv_bps should be rejected");
+
+    aura_store_close(store);
+}
+
+void TestValidateSnapshotRejectsNegativeNetSent() {
+    aura_error_t error{};
+    aura_store_t* store = nullptr;
+    int rc = aura_store_open(":memory:", 3600.0, &store, &error);
+    ExpectEq(rc, AURA_OK, "neg net_sent: store open");
+
+    aura_snapshot_t snap{};
+    snap.timestamp = NowSeconds();
+    snap.cpu_percent = 10.0;
+    snap.memory_percent = 20.0;
+    snap.net_sent_bps = -1.0;
+
+    rc = aura_store_append(store, &snap, &error);
+    ExpectTrue(rc != AURA_OK, "negative net_sent_bps should be rejected");
+
+    aura_store_close(store);
+}
+
+void TestValidateSnapshotRejectsInfiniteNetRecv() {
+    aura_error_t error{};
+    aura_store_t* store = nullptr;
+    int rc = aura_store_open(":memory:", 3600.0, &store, &error);
+    ExpectEq(rc, AURA_OK, "inf net_recv: store open");
+
+    aura_snapshot_t snap{};
+    snap.timestamp = NowSeconds();
+    snap.cpu_percent = 10.0;
+    snap.memory_percent = 20.0;
+    snap.net_recv_bps = std::numeric_limits<double>::infinity();
+
+    rc = aura_store_append(store, &snap, &error);
+    ExpectTrue(rc != AURA_OK, "infinite net_recv_bps should be rejected");
+
+    aura_store_close(store);
+}
+
+// ---------------------------------------------------------------------------
+// Network telemetry field tests — C API round-trip
+// ---------------------------------------------------------------------------
+
+void TestAbiSnapshotNetFieldsRoundTrip() {
+    aura_error_t error{};
+    aura_store_t* store = nullptr;
+    int rc = aura_store_open(":memory:", 3600.0, &store, &error);
+    ExpectEq(rc, AURA_OK, "abi net roundtrip: store open");
+
+    const double base = NowSeconds();
+    aura_snapshot_t snap{};
+    snap.timestamp = base;
+    snap.cpu_percent = 25.0;
+    snap.memory_percent = 35.0;
+    snap.disk_read_bps = 100000.0;
+    snap.disk_write_bps = 200000.0;
+    snap.net_recv_bps = 9876543.0;
+    snap.net_sent_bps = 1234567.0;
+
+    rc = aura_store_append(store, &snap, &error);
+    ExpectEq(rc, AURA_OK, "abi net roundtrip: append");
+
+    aura_snapshot_t latest[1]{};
+    int out_count = 0;
+    rc = aura_store_latest(store, 1, latest, 1, &out_count, &error);
+    ExpectEq(rc, AURA_OK, "abi net roundtrip: latest");
+    ExpectEq(out_count, 1, "abi net roundtrip: count");
+    ExpectNear(latest[0].timestamp, base, 1e-9, "abi net roundtrip: timestamp");
+    ExpectNear(latest[0].cpu_percent, 25.0, 1e-3, "abi net roundtrip: cpu");
+    ExpectNear(latest[0].memory_percent, 35.0, 1e-3, "abi net roundtrip: mem");
+    ExpectNear(latest[0].disk_read_bps, 100000.0, 1e-3, "abi net roundtrip: disk_r");
+    ExpectNear(latest[0].disk_write_bps, 200000.0, 1e-3, "abi net roundtrip: disk_w");
+    ExpectNear(latest[0].net_recv_bps, 9876543.0, 1e-3, "abi net roundtrip: net_recv");
+    ExpectNear(latest[0].net_sent_bps, 1234567.0, 1e-3, "abi net roundtrip: net_sent");
+
+    aura_store_close(store);
+}
+
+void TestAbiSnapshotNetFieldsZeroInit() {
+    aura_error_t error{};
+    aura_store_t* store = nullptr;
+    int rc = aura_store_open(":memory:", 3600.0, &store, &error);
+    ExpectEq(rc, AURA_OK, "abi zero init: store open");
+
+    const double base = NowSeconds();
+    aura_snapshot_t snap{};
+    snap.timestamp = base;
+    snap.cpu_percent = 5.0;
+    snap.memory_percent = 10.0;
+
+    rc = aura_store_append(store, &snap, &error);
+    ExpectEq(rc, AURA_OK, "abi zero init: append");
+
+    aura_snapshot_t latest[1]{};
+    int out_count = 0;
+    rc = aura_store_latest(store, 1, latest, 1, &out_count, &error);
+    ExpectEq(rc, AURA_OK, "abi zero init: latest");
+    ExpectNear(latest[0].disk_read_bps, 0.0, 1e-9, "abi zero init: disk_read zero");
+    ExpectNear(latest[0].disk_write_bps, 0.0, 1e-9, "abi zero init: disk_write zero");
+    ExpectNear(latest[0].net_recv_bps, 0.0, 1e-9, "abi zero init: net_recv zero");
+    ExpectNear(latest[0].net_sent_bps, 0.0, 1e-9, "abi zero init: net_sent zero");
+
+    aura_store_close(store);
+}

--- a/tests/test_platform/native/test_platform_tests.hpp
+++ b/tests/test_platform/native/test_platform_tests.hpp
@@ -1,11 +1,11 @@
 #pragma once
 
 // ---------------------------------------------------------------------------
-// Forward declarations for all 47 platform test functions.
+// Forward declarations for all 66 platform test functions.
 // Each is defined in one of the four translation units:
 //   test_platform_config.cpp  (5 config tests)
-//   test_platform_store.cpp   (6 store tests)
-//   test_platform_dvr.cpp     (30 DVR tests)
+//   test_platform_store.cpp   (20 store tests)
+//   test_platform_dvr.cpp     (35 DVR tests)
 //   test_platform_native.cpp  (6 remaining tests)
 // ---------------------------------------------------------------------------
 
@@ -77,3 +77,32 @@ void TestSqlitePrunePeriodic();
 
 // Concurrency test
 void TestSqliteConcurrentReadWrite();
+
+// Network field store persistence tests (4)
+void TestSnapshotNetFieldsPersisted();
+void TestSnapshotNetFieldsPersistedToFile();
+void TestSnapshotNetFieldsDefaultToZero();
+void TestSnapshotNetFieldsInBetweenQuery();
+
+// Schema migration tests (5)
+void TestSchemaMigrationAddsNetColumns();
+void TestSchemaMigrationIdempotent();
+void TestCsvMigration7FieldLines();
+void TestCsvMigration5FieldLinesNetDefaultZero();
+void TestCsvMigrationMixed5And7FieldLines();
+
+// DVR tests — LTTB with network fields (5)
+void TestLttbNetRecvSpikePreserved();
+void TestLttbNetSentSpikePreserved();
+void TestLttbPreservesAllFieldsIncludingNet();
+void TestLttbNetFieldsZeroRangeSkipped();
+void TestLttbSixFieldNormalizationNetVsCpu();
+
+// Validation tests — network fields (3)
+void TestValidateSnapshotRejectsNegativeNetRecv();
+void TestValidateSnapshotRejectsNegativeNetSent();
+void TestValidateSnapshotRejectsInfiniteNetRecv();
+
+// C API round-trip tests — network fields (2)
+void TestAbiSnapshotNetFieldsRoundTrip();
+void TestAbiSnapshotNetFieldsZeroInit();


### PR DESCRIPTION
## Summary
This PR extends the telemetry snapshot structure to include network bandwidth metrics (`net_recv_bps` and `net_sent_bps`), enabling the platform to track network receive and send rates alongside existing CPU, memory, and disk metrics.

## Key Changes

### Core Data Structure
- Added two new `double` fields to `aura_snapshot_t` struct: `net_recv_bps` and `net_sent_bps`
- Updated `Snapshot` internal struct to include the new network fields with default initialization to 0.0
- Incremented `AURA_PLATFORM_ABI_VERSION` from 1 to 2 to reflect the breaking ABI change

### Database & Persistence
- Extended SQLite schema to store network fields in columns 6 and 7
- Updated CSV parsing logic to handle both 5-field (legacy, net defaults to 0) and 7-field (with net) formats
- Modified insert/select statements to bind and retrieve network field values
- Implemented backward-compatible schema migration that adds net columns to existing databases

### Data Validation
- Added validation to reject negative values for `net_recv_bps` and `net_sent_bps`
- Added validation to reject infinite values for network fields

### Downsampling (LTTB)
- Updated LTTB algorithm to normalize and preserve network field spikes alongside existing metrics
- Changed field count from 4 to 6 to include network metrics in area calculations
- Ensured zero-range network fields are properly skipped in normalization

### CLI & Output
- Updated JSON output format to include `net_recv_bps` and `net_sent_bps` fields
- Updated text output format to display network metrics

### Testing
- Added 19 comprehensive tests covering:
  - Network field persistence in memory and file-based stores
  - Default zero initialization for backward compatibility
  - Schema migration from 5-field to 7-field CSV format
  - Mixed CSV format handling (5-field and 7-field lines in same file)
  - Validation of negative and infinite network values
  - LTTB spike preservation for network metrics
  - C API round-trip serialization/deserialization
  - Field normalization with disparate scales (CPU 0-100 vs net 0-1e9)

## Implementation Details
- Network fields default to 0.0 for backward compatibility with existing snapshots
- CSV parsing gracefully handles both legacy (5-field) and new (7-field) formats
- LTTB normalization properly scales network metrics (which can reach 1e9) relative to other metrics
- All existing functionality remains unchanged; this is purely additive

https://claude.ai/code/session_013WEz1wFJnhn7fbEVHSjzSH