### PR TITLE
feat(shell): integrate analytics engines — health gauge, trend arrows, alert badge

### DIFF
--- a/src/shell/native/CMakeLists.txt
+++ b/src/shell/native/CMakeLists.txt
@@ -18,6 +18,7 @@ set(AURA_SHELL_CORE_SOURCES
     src/cockpit_controller.cpp
     src/cockpit_controller_support.cpp
     src/dock_model.cpp
+    src/analytics_bridge.cpp
     src/persistence_bridge.cpp
     src/render_bridge.cpp
     src/telemetry_bridge.cpp

--- a/src/shell/native/include/aura_shell/analytics_bridge.hpp
+++ b/src/shell/native/include/aura_shell/analytics_bridge.hpp
@@ -1,0 +1,107 @@
+#pragma once
+
+#include "aura_shell/cockpit_types.hpp"
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace aura::shell {
+
+struct TrendResult {
+    TrendDirection direction{TrendDirection::Stable};
+    double slope{0.0};
+    double r_squared{0.0};
+};
+
+class IAnalyticsBridge {
+public:
+    virtual ~IAnalyticsBridge() = default;
+
+    virtual bool available() const = 0;
+    virtual bool smoother_available() const = 0;
+    virtual bool alerts_available() const = 0;
+    virtual bool health_available() const = 0;
+    virtual bool trend_available() const = 0;
+    virtual bool dvr_stats_available() const = 0;
+
+    virtual std::optional<HealthScoreState> compute_health_score(
+        const AnalyticsSnapshot& snapshot, std::string& error) = 0;
+
+    virtual std::optional<TrendResult> detect_trend(
+        const std::vector<AnalyticsSnapshot>& snapshots,
+        int metric, double sensitivity, std::string& error) = 0;
+
+    virtual std::optional<AnalyticsSnapshot> smooth(
+        const AnalyticsSnapshot& snapshot, std::string& error) = 0;
+
+    virtual bool reset_smoother(std::string& error) = 0;
+
+    virtual bool evaluate_alerts(const AnalyticsSnapshot& snapshot, std::string& error) = 0;
+
+    virtual std::vector<ActiveAlert> get_active_alerts(std::string& error) = 0;
+
+    virtual bool acknowledge_alert(int rule_id, std::string& error) = 0;
+
+    virtual std::optional<DvrStatsResult> compute_dvr_stats(
+        void* store_handle, double start, double end, std::string& error) = 0;
+
+    virtual bool export_json(void* store_handle, double start, double end,
+        bool include_stats, const std::string& path, std::string& error) = 0;
+
+    virtual bool export_csv(void* store_handle, double start, double end,
+        const std::string& path, std::string& error) = 0;
+};
+
+class AnalyticsBridge final : public IAnalyticsBridge {
+public:
+    AnalyticsBridge();
+    ~AnalyticsBridge() override;
+
+    AnalyticsBridge(const AnalyticsBridge&) = delete;
+    AnalyticsBridge& operator=(const AnalyticsBridge&) = delete;
+
+    bool available() const override;
+    bool smoother_available() const override;
+    bool alerts_available() const override;
+    bool health_available() const override;
+    bool trend_available() const override;
+    bool dvr_stats_available() const override;
+
+    std::optional<HealthScoreState> compute_health_score(
+        const AnalyticsSnapshot& snapshot, std::string& error) override;
+
+    std::optional<TrendResult> detect_trend(
+        const std::vector<AnalyticsSnapshot>& snapshots,
+        int metric, double sensitivity, std::string& error) override;
+
+    std::optional<AnalyticsSnapshot> smooth(
+        const AnalyticsSnapshot& snapshot, std::string& error) override;
+
+    bool reset_smoother(std::string& error) override;
+
+    bool evaluate_alerts(const AnalyticsSnapshot& snapshot, std::string& error) override;
+
+    std::vector<ActiveAlert> get_active_alerts(std::string& error) override;
+
+    bool acknowledge_alert(int rule_id, std::string& error) override;
+
+    std::optional<DvrStatsResult> compute_dvr_stats(
+        void* store_handle, double start, double end, std::string& error) override;
+
+    bool export_json(void* store_handle, double start, double end,
+        bool include_stats, const std::string& path, std::string& error) override;
+
+    bool export_csv(void* store_handle, double start, double end,
+        const std::string& path, std::string& error) override;
+
+    std::string loaded_path() const;
+    std::string load_error() const;
+
+private:
+    struct Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+}  // namespace aura::shell

--- a/src/shell/native/include/aura_shell/cockpit_controller.hpp
+++ b/src/shell/native/include/aura_shell/cockpit_controller.hpp
@@ -6,6 +6,7 @@
 #include <string>
 #include <vector>
 
+#include "aura_shell/analytics_bridge.hpp"
 #include "aura_shell/cockpit_types.hpp"
 #include "aura_shell/persistence_bridge.hpp"
 #include "aura_shell/render_bridge.hpp"
@@ -27,6 +28,9 @@ public:
         bool prefer_dvr_timeline{true};
         bool persistence_enabled{true};
         double retention_seconds{604800.0};
+        std::size_t snapshot_buffer_capacity{60};
+        double trend_sensitivity{0.5};
+        std::size_t analytics_refresh_ticks{3};
     };
 
     CockpitController(
@@ -34,7 +38,8 @@ public:
         std::unique_ptr<IRenderBridge> render_bridge,
         std::unique_ptr<ITimelineBridge> timeline_bridge,
         Config config = {},
-        std::unique_ptr<IPersistenceBridge> persistence_bridge = nullptr
+        std::unique_ptr<IPersistenceBridge> persistence_bridge = nullptr,
+        std::unique_ptr<IAnalyticsBridge> analytics_bridge = nullptr
     );
 
     CockpitUiState tick(
@@ -43,6 +48,13 @@ public:
     );
 
     const CockpitUiState& last_state() const;
+
+    void set_smoothing_enabled(bool enabled);
+    bool smoothing_enabled() const;
+    bool acknowledge_alert(int rule_id, std::string& error);
+    std::optional<DvrStatsResult> compute_dvr_stats(std::string& error);
+    bool export_dvr_json(const std::string& path, std::string& error);
+    bool export_dvr_csv(const std::string& path, std::string& error);
 
 private:
     static double now_seconds();
@@ -71,6 +83,7 @@ private:
     std::unique_ptr<IRenderBridge> render_bridge_;
     std::unique_ptr<ITimelineBridge> timeline_bridge_;
     std::unique_ptr<IPersistenceBridge> persistence_bridge_;
+    std::unique_ptr<IAnalyticsBridge> analytics_bridge_;
     bool persistence_active_{false};
     Config config_;
     double frame_phase_{0.0};
@@ -84,6 +97,10 @@ private:
     std::size_t tick_count_{0};
     GpuState cached_gpu_;
     ThermalState cached_thermal_;
+
+    std::vector<AnalyticsSnapshot> snapshot_buffer_;
+    std::size_t ticks_since_analytics_{0};
+    bool smoothing_enabled_{false};
 };
 
 }  // namespace aura::shell

--- a/src/shell/native/include/aura_shell/cockpit_types.hpp
+++ b/src/shell/native/include/aura_shell/cockpit_types.hpp
@@ -103,6 +103,57 @@ struct ThermalState {
     double hottest_celsius{0.0};
 };
 
+enum class TrendDirection : int { Stable = 0, Rising = 1, Falling = 2 };
+
+struct HealthScoreState {
+    bool available{false};
+    double overall{50.0};
+    double cpu{50.0};
+    double memory{50.0};
+    double disk{50.0};
+    double network{50.0};
+};
+
+struct ActiveAlert {
+    int rule_id{0};
+    int state{0};       // 0=idle, 1=pending, 2=triggered, 3=cooldown
+    double last_value{0.0};
+    double peak_value{0.0};
+    double duration{0.0};
+    bool acknowledged{false};
+};
+
+struct MetricStats {
+    double avg{0.0};
+    double min_val{0.0};
+    double max_val{0.0};
+    double p50{0.0};
+    double p95{0.0};
+    double p99{0.0};
+    double stddev{0.0};
+};
+
+struct DvrStatsResult {
+    int count{0};
+    double duration_seconds{0.0};
+    MetricStats cpu;
+    MetricStats memory;
+    MetricStats disk_read;
+    MetricStats disk_write;
+    MetricStats net_recv;
+    MetricStats net_sent;
+};
+
+struct AnalyticsSnapshot {
+    double timestamp{0.0};
+    double cpu_percent{0.0};
+    double memory_percent{0.0};
+    double disk_read_bps{0.0};
+    double disk_write_bps{0.0};
+    double net_recv_bps{0.0};
+    double net_sent_bps{0.0};
+};
+
 struct CockpitUiState {
     double timestamp{0.0};
     double cpu_percent{0.0};
@@ -134,6 +185,12 @@ struct CockpitUiState {
     DiskIoState disk_io;
     NetworkIoState network_io;
     ThermalState thermal;
+
+    HealthScoreState health;
+    TrendDirection cpu_trend{TrendDirection::Stable};
+    TrendDirection memory_trend{TrendDirection::Stable};
+    bool smoothing_active{false};
+    std::vector<ActiveAlert> active_alerts;
 };
 
 }  // namespace aura::shell

--- a/src/shell/native/include/aura_shell/persistence_bridge.hpp
+++ b/src/shell/native/include/aura_shell/persistence_bridge.hpp
@@ -12,6 +12,7 @@ public:
     virtual bool open_store(const std::string& db_path, double retention_seconds, std::string& error) = 0;
     virtual bool append_snapshot(double ts, double cpu, double mem, double disk_r, double disk_w, std::string& error) = 0;
     virtual void close_store() = 0;
+    virtual void* store_handle() const = 0;
 };
 
 class PersistenceBridge final : public IPersistenceBridge {
@@ -26,6 +27,7 @@ public:
     bool open_store(const std::string& db_path, double retention_seconds, std::string& error) override;
     bool append_snapshot(double ts, double cpu, double mem, double disk_r, double disk_w, std::string& error) override;
     void close_store() override;
+    void* store_handle() const override;
 
     std::string loaded_path() const;
     std::string load_error() const;

--- a/src/shell/native/qml/CockpitScene.qml
+++ b/src/shell/native/qml/CockpitScene.qml
@@ -62,6 +62,26 @@ Rectangle {
     property real thermalHottest: 0.0
     property var thermalSensors: []
 
+    // ── Analytics bridge properties ────────────────────────────────────────
+    property bool healthAvailable: false
+    property real healthOverall: 50.0
+    property real healthCpu: 50.0
+    property real healthMemory: 50.0
+    property real healthDisk: 50.0
+    property real healthNetwork: 50.0
+    property int cpuTrend: 0    // 0=stable, 1=rising, 2=falling
+    property int memoryTrend: 0
+    property bool smoothingActive: false
+    property var activeAlerts: []
+
+    // Smoothed health for gauge animation
+    property real smoothHealth: 50.0
+    property bool hasHealthSample: false
+    onHealthOverallChanged: {
+        if (!hasHealthSample) { smoothHealth = healthOverall; hasHealthSample = true }
+        else { smoothHealth = smoothHealth * 0.80 + healthOverall * 0.20 }
+    }
+
     // Smoothed GPU value
     property real smoothGpu: 0.0
     property bool hasGpuSample: false
@@ -220,6 +240,105 @@ Rectangle {
             Math.max(0, Math.min(1, b)),
             alpha
         )
+    }
+
+    // ── Health gauge color (inverted: high=green, low=red) ─────────────────
+    function healthGaugeColor(score, alpha) {
+        var r, g, b
+        if (score < 50) {
+            var t = score / 50.0
+            r = 0.937 + (0.961 - 0.937) * t
+            g = 0.267 + (0.620 - 0.267) * t
+            b = 0.267 + (0.043 - 0.267) * t
+        } else if (score < 80) {
+            var t2 = (score - 50) / 30.0
+            r = 0.961 + (0.133 - 0.961) * t2
+            g = 0.620 + (0.773 - 0.620) * t2
+            b = 0.043 + (0.369 - 0.043) * t2
+        } else {
+            var t3 = (score - 80) / 20.0
+            r = 0.133 + (0.133 - 0.133) * t3
+            g = 0.773 + (0.773 - 0.773) * t3
+            b = 0.369 + (0.369 - 0.369) * t3
+        }
+        return Qt.rgba(
+            Math.max(0, Math.min(1, r)),
+            Math.max(0, Math.min(1, g)),
+            Math.max(0, Math.min(1, b)),
+            alpha
+        )
+    }
+
+    // ── Health gauge arc drawing ──────────────────────────────────────────
+    function drawHealthGauge(ctx, w, h, score, sf) {
+        ctx.clearRect(0, 0, w, h)
+        var cx = w / 2, cy = h / 2
+        var r = w / 2 - Math.max(6, Math.round(10 * sf))
+        var trackW = Math.max(5, Math.round(11 * sf))
+        var startAngle = Math.PI * 0.75
+        var fullSweep = Math.PI * 1.50
+        var endAngle = startAngle + fullSweep * (score / 100.0)
+
+        // Track arc
+        ctx.beginPath()
+        ctx.arc(cx, cy, r, startAngle, startAngle + fullSweep, false)
+        ctx.strokeStyle = root.clrTrack
+        ctx.lineWidth = trackW
+        ctx.lineCap = "butt"
+        ctx.stroke()
+
+        // Tick marks at 25%, 50%, 75%
+        ctx.strokeStyle = root.clrTrackTick
+        ctx.lineWidth = 2
+        var ticks = [0.25, 0.50, 0.75]
+        for (var i = 0; i < ticks.length; i++) {
+            var ta = startAngle + fullSweep * ticks[i]
+            ctx.beginPath()
+            ctx.arc(cx, cy, r, ta, ta + 0.012, false)
+            ctx.lineWidth = trackW + 2
+            ctx.stroke()
+        }
+
+        // Value arc
+        if (score > 0.2) {
+            var gc = root.healthGaugeColor(score, 1.0)
+            var grad = ctx.createLinearGradient(
+                cx + r * Math.cos(startAngle), cy + r * Math.sin(startAngle),
+                cx + r * Math.cos(endAngle), cy + r * Math.sin(endAngle)
+            )
+            var gcStart = root.healthGaugeColor(Math.max(0, score * 0.5), 1.0)
+            grad.addColorStop(0.0, Qt.rgba(gcStart.r, gcStart.g, gcStart.b, 0.85))
+            grad.addColorStop(1.0, Qt.rgba(gc.r, gc.g, gc.b, 1.00))
+            ctx.beginPath()
+            ctx.arc(cx, cy, r, startAngle, endAngle, false)
+            ctx.strokeStyle = grad
+            ctx.lineWidth = trackW
+            ctx.lineCap = "round"
+            ctx.stroke()
+
+            // Leading dot
+            var dotX = cx + r * Math.cos(endAngle)
+            var dotY = cy + r * Math.sin(endAngle)
+            ctx.beginPath()
+            ctx.arc(dotX, dotY, trackW * 0.55, 0, Math.PI * 2, false)
+            ctx.fillStyle = Qt.rgba(gc.r, gc.g, gc.b, 1.0)
+            ctx.fill()
+        }
+    }
+
+    // ── Trend arrow helper ───────────────────────────────────────────────
+    function trendArrow(direction) {
+        if (direction === 1) return "\u2191"  // Rising
+        if (direction === 2) return "\u2193"  // Falling
+        return "\u2192"                        // Stable
+    }
+    function trendColor(direction) {
+        if (direction === 1) return "#f47272"  // Red — rising usage is bad
+        if (direction === 2) return "#6ee7b7"  // Green — falling usage is good
+        return root.clrTextMuted               // Muted for stable
+    }
+    function trendOpacity(direction) {
+        return direction === 0 ? 0.4 : 0.85
     }
 
     // ── Rate formatting helper ──────────────────────────────────────────────
@@ -1143,6 +1262,17 @@ Rectangle {
                         font.letterSpacing: 2.5
                     }
 
+                    // Trend arrow
+                    Text {
+                        anchors.horizontalCenter: parent.horizontalCenter
+                        visible: root.healthAvailable
+                        text: root.trendArrow(root.cpuTrend)
+                        color: root.trendColor(root.cpuTrend)
+                        font.pixelSize: Math.max(7, root.fontGaugeLabel * 0.75)
+                        font.weight: Font.Bold
+                        opacity: root.trendOpacity(root.cpuTrend)
+                    }
+
                     // Kawaii mood face (pink mode)
                     Text {
                         anchors.horizontalCenter: parent.horizontalCenter
@@ -1242,6 +1372,17 @@ Rectangle {
                         font.letterSpacing: 2.5
                     }
 
+                    // Trend arrow
+                    Text {
+                        anchors.horizontalCenter: parent.horizontalCenter
+                        visible: root.healthAvailable
+                        text: root.trendArrow(root.memoryTrend)
+                        color: root.trendColor(root.memoryTrend)
+                        font.pixelSize: Math.max(7, root.fontGaugeLabel * 0.75)
+                        font.weight: Font.Bold
+                        opacity: root.trendOpacity(root.memoryTrend)
+                    }
+
                     // Kawaii mood face (pink mode)
                     Text {
                         anchors.horizontalCenter: parent.horizontalCenter
@@ -1317,6 +1458,93 @@ Rectangle {
                     }
                 }
             }
+            // ── Health gauge — visible when analytics engine available ────
+            Item {
+                id: healthGaugeItem
+                width: root.effectiveGaugeSize
+                height: root.effectiveGaugeSize
+                visible: root.healthAvailable
+
+                Canvas {
+                    id: healthGlowCanvas
+                    anchors.centerIn: parent
+                    width: parent.width + Math.round(10 + 10 * root.scaleFactor)
+                    height: parent.height + Math.round(10 + 10 * root.scaleFactor)
+                    opacity: 0.30 + root.accentIntensity * 0.15
+                    onPaint: root.drawGlowHalo(getContext("2d"), width, height, root.smoothHealth, parent.width, root.scaleFactor)
+                    Connections {
+                        target: root
+                        function onSmoothHealthChanged() { healthGlowCanvas.requestPaint() }
+                    }
+                }
+
+                Canvas {
+                    id: healthArcCanvas
+                    anchors.centerIn: parent
+                    width: parent.width
+                    height: parent.height
+                    onPaint: root.drawHealthGauge(getContext("2d"), width, height, root.smoothHealth, root.scaleFactor)
+                    Connections {
+                        target: root
+                        function onSmoothHealthChanged() { healthArcCanvas.requestPaint() }
+                    }
+                }
+
+                Column {
+                    anchors.centerIn: parent
+                    anchors.verticalCenterOffset: 4
+                    spacing: 2
+
+                    Text {
+                        anchors.horizontalCenter: parent.horizontalCenter
+                        text: root.smoothHealth.toFixed(0)
+                        color: root.clrTextPrimary
+                        font.pixelSize: root.fontGaugeValue
+                        font.weight: Font.Bold
+                    }
+                    Text {
+                        anchors.horizontalCenter: parent.horizontalCenter
+                        text: "HEALTH"
+                        color: root.clrTextSecondary
+                        font.pixelSize: root.fontGaugeLabel
+                        font.weight: Font.Medium
+                        font.letterSpacing: 2.5
+                    }
+                }
+            }
+
+            // ── Health sub-score pills (below health gauge) ──────────────
+            Column {
+                visible: root.healthAvailable && root.showExtended
+                anchors.verticalCenter: parent.verticalCenter
+                spacing: Math.round(3 * root.scaleFactor)
+
+                Repeater {
+                    model: [
+                        { label: "CPU", score: root.healthCpu },
+                        { label: "MEM", score: root.healthMemory },
+                        { label: "DISK", score: root.healthDisk },
+                        { label: "NET", score: root.healthNetwork }
+                    ]
+                    Rectangle {
+                        width: Math.max(44, Math.round(52 * root.scaleFactor))
+                        height: Math.max(14, Math.round(16 * root.scaleFactor))
+                        radius: height * 0.3
+                        color: root.healthGaugeColor(modelData.score, 0.12)
+                        border.width: 1
+                        border.color: root.healthGaugeColor(modelData.score, 0.30)
+
+                        Text {
+                            anchors.centerIn: parent
+                            text: modelData.label + " " + modelData.score.toFixed(0)
+                            color: root.healthGaugeColor(modelData.score, 0.90)
+                            font.pixelSize: Math.max(7, Math.round(root.fontGaugeLabel * 0.7))
+                            font.weight: Font.DemiBold
+                            font.letterSpacing: 0.5
+                        }
+                    }
+                }
+            }
         } // Row gaugeRow
 
         // ── Between-gauge kawaii connector (pink mode) ─────────────────────
@@ -1351,6 +1579,37 @@ Rectangle {
                         }
                     }
                 }
+            }
+        }
+
+        // ── Alert badge ──────────────────────────────────────────────────────
+        Rectangle {
+            id: alertBadge
+            Layout.alignment: Qt.AlignHCenter
+            Layout.preferredHeight: alertBadgeText.implicitHeight + Math.round(8 * root.scaleFactor)
+            Layout.preferredWidth: alertBadgeText.implicitWidth + Math.round(24 * root.scaleFactor)
+            visible: root.activeAlerts.length > 0
+            radius: height / 2
+            color: Qt.rgba(0.93, 0.27, 0.27, 0.15)
+            border.width: 1
+            border.color: Qt.rgba(0.93, 0.27, 0.27, 0.45)
+
+            property real pulseOpacity: 1.0
+            SequentialAnimation on pulseOpacity {
+                running: alertBadge.visible
+                loops: Animation.Infinite
+                NumberAnimation { to: 0.6; duration: 800; easing.type: Easing.InOutSine }
+                NumberAnimation { to: 1.0; duration: 800; easing.type: Easing.InOutSine }
+            }
+
+            Text {
+                id: alertBadgeText
+                anchors.centerIn: parent
+                text: root.activeAlerts.length + (root.activeAlerts.length === 1 ? " ALERT" : " ALERTS")
+                color: Qt.rgba(0.93, 0.27, 0.27, parent.pulseOpacity)
+                font.pixelSize: Math.max(8, Math.round(root.fontGaugeLabel * 0.85))
+                font.weight: Font.Bold
+                font.letterSpacing: 1.5
             }
         }
 

--- a/src/shell/native/qml/TimelineScene.qml
+++ b/src/shell/native/qml/TimelineScene.qml
@@ -35,6 +35,12 @@ Rectangle {
     property int severityLevel: 0
     property bool gpuAvailable: false
 
+    // ── Analytics properties ──────────────────────────────────────────────
+    property bool dvrStatsAvailable: false
+    property var dvrStats: ({})
+    property bool showStats: false
+    property bool exportRequested: false
+
     readonly property bool pinkMode: themeMode === "pink_cute"
     readonly property bool hasData: timelinePoints.length >= 2
 
@@ -150,6 +156,119 @@ Rectangle {
                     font.letterSpacing: 1
                     font.family: "Segoe UI"
                 }
+            }
+        }
+    }
+
+    // ── Stats + Export pills (top-right, below legend) ─────────────────────
+    Row {
+        anchors.right: parent.right
+        anchors.top: parent.top
+        anchors.rightMargin: marginH
+        anchors.topMargin: marginV + badgeSize * 2.2
+        spacing: Math.max(4, root.width * 0.012)
+        visible: root.hasData
+
+        Rectangle {
+            width: statsPillText.implicitWidth + badgeSize * 1.2
+            height: statsPillText.implicitHeight + badgeSize * 0.5
+            radius: height * 0.3
+            color: root.showStats ? Qt.rgba(accentRed, accentGreen, accentBlue, 0.20) : "transparent"
+            border.width: 1
+            border.color: Qt.rgba(accentRed, accentGreen, accentBlue, root.showStats ? 0.50 : 0.25)
+            visible: root.dvrStatsAvailable
+
+            Text {
+                id: statsPillText
+                anchors.centerIn: parent
+                text: "STATS"
+                color: Qt.rgba(accentRed, accentGreen, accentBlue, root.showStats ? 1.0 : 0.6)
+                font.pixelSize: badgeSize
+                font.weight: Font.DemiBold
+                font.letterSpacing: 1
+                font.family: "Segoe UI"
+            }
+
+            MouseArea {
+                anchors.fill: parent
+                cursorShape: Qt.PointingHandCursor
+                onClicked: root.showStats = !root.showStats
+            }
+        }
+
+        Rectangle {
+            width: exportPillText.implicitWidth + badgeSize * 1.2
+            height: exportPillText.implicitHeight + badgeSize * 0.5
+            radius: height * 0.3
+            color: "transparent"
+            border.width: 1
+            border.color: Qt.rgba(0.96, 0.62, 0.04, 0.25)
+
+            Text {
+                id: exportPillText
+                anchors.centerIn: parent
+                text: "EXPORT"
+                color: Qt.rgba(0.96, 0.62, 0.04, 0.7)
+                font.pixelSize: badgeSize
+                font.weight: Font.DemiBold
+                font.letterSpacing: 1
+                font.family: "Segoe UI"
+            }
+
+            MouseArea {
+                anchors.fill: parent
+                cursorShape: Qt.PointingHandCursor
+                onClicked: root.exportRequested = true
+            }
+        }
+    }
+
+    // ── Stats overlay (bottom-left of chart area) ────────────────────────
+    Rectangle {
+        id: statsOverlay
+        anchors.left: chartCanvas.left
+        anchors.bottom: chartCanvas.bottom
+        anchors.leftMargin: 4
+        anchors.bottomMargin: 4
+        width: statsColumn.implicitWidth + Math.round(16 * (root.height / 300))
+        height: statsColumn.implicitHeight + Math.round(12 * (root.height / 300))
+        radius: 4
+        color: root.pinkMode ? Qt.rgba(0.12, 0.04, 0.09, 0.85) : Qt.rgba(0.03, 0.05, 0.10, 0.85)
+        border.width: 1
+        border.color: Qt.rgba(accentRed, accentGreen, accentBlue, 0.15)
+        visible: root.showStats && root.dvrStatsAvailable && root.hasData
+        z: 10
+
+        Column {
+            id: statsColumn
+            anchors.centerIn: parent
+            spacing: 2
+
+            Text {
+                text: {
+                    var s = root.dvrStats
+                    if (!s || !s.cpuAvg) return "CPU: --"
+                    return "CPU: avg " + Number(s.cpuAvg).toFixed(0) + "%" +
+                           " | p95 " + Number(s.cpuP95).toFixed(0) + "%" +
+                           " | max " + Number(s.cpuMax).toFixed(0) + "%" +
+                           " | \u03c3 " + Number(s.cpuStddev).toFixed(1)
+                }
+                color: root.clrTextSecondary
+                font.pixelSize: root.smallSize
+                font.family: "Segoe UI"
+            }
+            Text {
+                text: {
+                    var s = root.dvrStats
+                    if (!s || !s.memAvg) return "MEM: --"
+                    return "MEM: avg " + Number(s.memAvg).toFixed(0) + "%" +
+                           " | p95 " + Number(s.memP95).toFixed(0) + "%" +
+                           " | max " + Number(s.memMax).toFixed(0) + "%" +
+                           " | \u03c3 " + Number(s.memStddev).toFixed(1)
+                }
+                color: root.clrTextSecondary
+                font.pixelSize: root.smallSize
+                font.family: "Segoe UI"
             }
         }
     }

--- a/src/shell/native/src/analytics_bridge.cpp
+++ b/src/shell/native/src/analytics_bridge.cpp
@@ -1,0 +1,674 @@
+#include "aura_shell/analytics_bridge.hpp"
+
+#include "platform_dll_helpers.hpp"
+
+#include <cstring>
+#include <string>
+#include <vector>
+
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+#include <windows.h>
+
+#include "aura_platform.h"
+#endif
+
+namespace aura::shell {
+
+namespace {
+constexpr int kStatusOk = 0;
+}  // namespace
+
+struct AnalyticsBridge::Impl {
+#ifdef _WIN32
+    // Health score
+    using HealthScoreComputeFn = int (*)(const aura_snapshot_t*, aura_health_score_t*, aura_error_t*);
+
+    // Trend detection
+    using TrendDetectFn = int (*)(const aura_snapshot_t*, int, int, double, aura_trend_result_t*, aura_error_t*);
+
+    // EMA smoother
+    using SmootherCreateFn = int (*)(double, aura_smoother_t**, aura_error_t*);
+    using SmootherUpdateFn = int (*)(aura_smoother_t*, const aura_snapshot_t*, aura_snapshot_t*, aura_error_t*);
+    using SmootherResetFn = int (*)(aura_smoother_t*, aura_error_t*);
+    using SmootherDestroyFn = int (*)(aura_smoother_t*);
+
+    // Alert engine
+    using AlertEngineCreateFn = int (*)(aura_alert_engine_t**, aura_error_t*);
+    using AlertEngineDestroyFn = int (*)(aura_alert_engine_t*);
+    using AlertEngineAddRuleFn = int (*)(aura_alert_engine_t*, const aura_alert_rule_t*, aura_error_t*);
+    using AlertEngineEvaluateFn = int (*)(aura_alert_engine_t*, const aura_snapshot_t*, aura_error_t*);
+    using AlertEngineGetActiveFn = int (*)(aura_alert_engine_t*, aura_alert_status_t*, int, int*, aura_error_t*);
+    using AlertEngineAcknowledgeFn = int (*)(aura_alert_engine_t*, int, aura_error_t*);
+
+    // DVR stats & export
+    using DvrComputeStatsFn = int (*)(aura_store_t*, int, double, int, double, aura_stats_result_t*, aura_error_t*);
+    using DvrExportJsonFn = int (*)(aura_store_t*, int, double, int, double, int, const char*, aura_error_t*);
+    using DvrExportCsvFn = int (*)(aura_store_t*, int, double, int, double, const char*, aura_error_t*);
+
+    HMODULE module_handle{nullptr};
+
+    // Function pointers
+    HealthScoreComputeFn health_score_compute_fn{nullptr};
+    TrendDetectFn trend_detect_fn{nullptr};
+    SmootherCreateFn smoother_create_fn{nullptr};
+    SmootherUpdateFn smoother_update_fn{nullptr};
+    SmootherResetFn smoother_reset_fn{nullptr};
+    SmootherDestroyFn smoother_destroy_fn{nullptr};
+    AlertEngineCreateFn alert_engine_create_fn{nullptr};
+    AlertEngineDestroyFn alert_engine_destroy_fn{nullptr};
+    AlertEngineAddRuleFn alert_engine_add_rule_fn{nullptr};
+    AlertEngineEvaluateFn alert_engine_evaluate_fn{nullptr};
+    AlertEngineGetActiveFn alert_engine_get_active_fn{nullptr};
+    AlertEngineAcknowledgeFn alert_engine_acknowledge_fn{nullptr};
+    DvrComputeStatsFn dvr_compute_stats_fn{nullptr};
+    DvrExportJsonFn dvr_export_json_fn{nullptr};
+    DvrExportCsvFn dvr_export_csv_fn{nullptr};
+
+    // Lazily created handles
+    aura_smoother_t* smoother_handle{nullptr};
+    aura_alert_engine_t* alert_engine_handle{nullptr};
+    bool alert_engine_initialized{false};
+#endif
+    bool loaded{false};
+    std::string loaded_path;
+    std::string load_error;
+};
+
+AnalyticsBridge::AnalyticsBridge() : impl_(std::make_unique<Impl>()) {
+#ifdef _WIN32
+    using namespace detail;
+
+    DWORD last_error_code = 0;
+    for (const auto& candidate : runtime_library_candidates()) {
+        const std::wstring path = candidate.wstring();
+        HMODULE module = LoadLibraryW(path.c_str());
+        if (module == nullptr) {
+            last_error_code = GetLastError();
+            continue;
+        }
+
+        // Health score
+        auto* health_compute = reinterpret_cast<Impl::HealthScoreComputeFn>(
+            GetProcAddress(module, "aura_health_score_compute"));
+
+        // Trend detection
+        auto* trend_detect = reinterpret_cast<Impl::TrendDetectFn>(
+            GetProcAddress(module, "aura_trend_detect"));
+
+        // At minimum we need health_score to consider the DLL useful for analytics.
+        // Other subsystems are optional.
+        if (health_compute == nullptr && trend_detect == nullptr) {
+            last_error_code = GetLastError();
+            FreeLibrary(module);
+            continue;
+        }
+
+        impl_->module_handle = module;
+        impl_->health_score_compute_fn = health_compute;
+        impl_->trend_detect_fn = trend_detect;
+
+        // EMA smoother (optional subsystem)
+        impl_->smoother_create_fn = reinterpret_cast<Impl::SmootherCreateFn>(
+            GetProcAddress(module, "aura_smoother_create"));
+        impl_->smoother_update_fn = reinterpret_cast<Impl::SmootherUpdateFn>(
+            GetProcAddress(module, "aura_smoother_update"));
+        impl_->smoother_reset_fn = reinterpret_cast<Impl::SmootherResetFn>(
+            GetProcAddress(module, "aura_smoother_reset"));
+        impl_->smoother_destroy_fn = reinterpret_cast<Impl::SmootherDestroyFn>(
+            GetProcAddress(module, "aura_smoother_destroy"));
+
+        // Alert engine (optional subsystem)
+        impl_->alert_engine_create_fn = reinterpret_cast<Impl::AlertEngineCreateFn>(
+            GetProcAddress(module, "aura_alert_engine_create"));
+        impl_->alert_engine_destroy_fn = reinterpret_cast<Impl::AlertEngineDestroyFn>(
+            GetProcAddress(module, "aura_alert_engine_destroy"));
+        impl_->alert_engine_add_rule_fn = reinterpret_cast<Impl::AlertEngineAddRuleFn>(
+            GetProcAddress(module, "aura_alert_engine_add_rule"));
+        impl_->alert_engine_evaluate_fn = reinterpret_cast<Impl::AlertEngineEvaluateFn>(
+            GetProcAddress(module, "aura_alert_engine_evaluate"));
+        impl_->alert_engine_get_active_fn = reinterpret_cast<Impl::AlertEngineGetActiveFn>(
+            GetProcAddress(module, "aura_alert_engine_get_active"));
+        impl_->alert_engine_acknowledge_fn = reinterpret_cast<Impl::AlertEngineAcknowledgeFn>(
+            GetProcAddress(module, "aura_alert_engine_acknowledge"));
+
+        // DVR stats & export (optional subsystem)
+        impl_->dvr_compute_stats_fn = reinterpret_cast<Impl::DvrComputeStatsFn>(
+            GetProcAddress(module, "aura_dvr_compute_stats"));
+        impl_->dvr_export_json_fn = reinterpret_cast<Impl::DvrExportJsonFn>(
+            GetProcAddress(module, "aura_dvr_export_json"));
+        impl_->dvr_export_csv_fn = reinterpret_cast<Impl::DvrExportCsvFn>(
+            GetProcAddress(module, "aura_dvr_export_csv"));
+
+        impl_->loaded = true;
+        impl_->loaded_path = narrow_from_wide(path);
+        impl_->load_error.clear();
+        return;
+    }
+
+    impl_->load_error = "Unable to load aura_platform.dll for analytics";
+    const std::string suffix = format_windows_error(last_error_code);
+    if (!suffix.empty()) {
+        impl_->load_error += ": " + suffix;
+    }
+#else
+    impl_->load_error = "Analytics bridge is only supported on Windows.";
+#endif
+}
+
+AnalyticsBridge::~AnalyticsBridge() {
+#ifdef _WIN32
+    if (impl_ != nullptr) {
+        if (impl_->smoother_handle != nullptr && impl_->smoother_destroy_fn != nullptr) {
+            impl_->smoother_destroy_fn(impl_->smoother_handle);
+            impl_->smoother_handle = nullptr;
+        }
+        if (impl_->alert_engine_handle != nullptr && impl_->alert_engine_destroy_fn != nullptr) {
+            impl_->alert_engine_destroy_fn(impl_->alert_engine_handle);
+            impl_->alert_engine_handle = nullptr;
+        }
+        if (impl_->module_handle != nullptr) {
+            FreeLibrary(impl_->module_handle);
+            impl_->module_handle = nullptr;
+        }
+    }
+#endif
+}
+
+bool AnalyticsBridge::available() const {
+    return impl_ != nullptr && impl_->loaded;
+}
+
+bool AnalyticsBridge::smoother_available() const {
+#ifdef _WIN32
+    return available() &&
+           impl_->smoother_create_fn != nullptr &&
+           impl_->smoother_update_fn != nullptr &&
+           impl_->smoother_reset_fn != nullptr &&
+           impl_->smoother_destroy_fn != nullptr;
+#else
+    return false;
+#endif
+}
+
+bool AnalyticsBridge::alerts_available() const {
+#ifdef _WIN32
+    return available() &&
+           impl_->alert_engine_create_fn != nullptr &&
+           impl_->alert_engine_destroy_fn != nullptr &&
+           impl_->alert_engine_add_rule_fn != nullptr &&
+           impl_->alert_engine_evaluate_fn != nullptr &&
+           impl_->alert_engine_get_active_fn != nullptr &&
+           impl_->alert_engine_acknowledge_fn != nullptr;
+#else
+    return false;
+#endif
+}
+
+bool AnalyticsBridge::health_available() const {
+#ifdef _WIN32
+    return available() && impl_->health_score_compute_fn != nullptr;
+#else
+    return false;
+#endif
+}
+
+bool AnalyticsBridge::trend_available() const {
+#ifdef _WIN32
+    return available() && impl_->trend_detect_fn != nullptr;
+#else
+    return false;
+#endif
+}
+
+bool AnalyticsBridge::dvr_stats_available() const {
+#ifdef _WIN32
+    return available() && impl_->dvr_compute_stats_fn != nullptr;
+#else
+    return false;
+#endif
+}
+
+namespace {
+#ifdef _WIN32
+aura_snapshot_t to_c_snapshot(const AnalyticsSnapshot& s) {
+    aura_snapshot_t c{};
+    c.timestamp = s.timestamp;
+    c.cpu_percent = s.cpu_percent;
+    c.memory_percent = s.memory_percent;
+    c.disk_read_bps = s.disk_read_bps;
+    c.disk_write_bps = s.disk_write_bps;
+    c.net_recv_bps = s.net_recv_bps;
+    c.net_sent_bps = s.net_sent_bps;
+    return c;
+}
+
+AnalyticsSnapshot from_c_snapshot(const aura_snapshot_t& c) {
+    AnalyticsSnapshot s;
+    s.timestamp = c.timestamp;
+    s.cpu_percent = c.cpu_percent;
+    s.memory_percent = c.memory_percent;
+    s.disk_read_bps = c.disk_read_bps;
+    s.disk_write_bps = c.disk_write_bps;
+    s.net_recv_bps = c.net_recv_bps;
+    s.net_sent_bps = c.net_sent_bps;
+    return s;
+}
+
+MetricStats from_c_metric_stats(const aura_metric_stats_t& c) {
+    MetricStats s;
+    s.avg = c.avg;
+    s.min_val = c.min;
+    s.max_val = c.max;
+    s.p50 = c.p50;
+    s.p95 = c.p95;
+    s.p99 = c.p99;
+    s.stddev = c.stddev;
+    return s;
+}
+#endif
+}  // namespace
+
+std::optional<HealthScoreState> AnalyticsBridge::compute_health_score(
+    const AnalyticsSnapshot& snapshot, std::string& error
+) {
+    error.clear();
+    if (!health_available()) {
+        error = "Health score computation unavailable.";
+        return std::nullopt;
+    }
+
+#ifdef _WIN32
+    using namespace detail;
+
+    aura_snapshot_t c_snap = to_c_snapshot(snapshot);
+    aura_health_score_t score{};
+    aura_error_t c_error{};
+    const int status = impl_->health_score_compute_fn(&c_snap, &score, &c_error);
+    if (status != kStatusOk) {
+        error = aura_error_message(c_error, "Health score computation failed.");
+        return std::nullopt;
+    }
+
+    HealthScoreState result;
+    result.available = true;
+    result.overall = score.overall;
+    result.cpu = score.cpu_score;
+    result.memory = score.memory_score;
+    result.disk = score.disk_score;
+    result.network = score.network_score;
+    return result;
+#else
+    error = "Analytics bridge is only supported on Windows.";
+    return std::nullopt;
+#endif
+}
+
+std::optional<TrendResult> AnalyticsBridge::detect_trend(
+    const std::vector<AnalyticsSnapshot>& snapshots,
+    const int metric, const double sensitivity, std::string& error
+) {
+    error.clear();
+    if (!trend_available()) {
+        error = "Trend detection unavailable.";
+        return std::nullopt;
+    }
+
+#ifdef _WIN32
+    using namespace detail;
+
+    std::vector<aura_snapshot_t> c_snaps;
+    c_snaps.reserve(snapshots.size());
+    for (const auto& s : snapshots) {
+        c_snaps.push_back(to_c_snapshot(s));
+    }
+
+    aura_trend_result_t c_trend{};
+    aura_error_t c_error{};
+    const int status = impl_->trend_detect_fn(
+        c_snaps.data(), static_cast<int>(c_snaps.size()),
+        metric, sensitivity, &c_trend, &c_error);
+    if (status != kStatusOk) {
+        error = aura_error_message(c_error, "Trend detection failed.");
+        return std::nullopt;
+    }
+
+    TrendResult result;
+    result.direction = static_cast<TrendDirection>(c_trend.direction);
+    result.slope = c_trend.slope;
+    result.r_squared = c_trend.r_squared;
+    return result;
+#else
+    error = "Analytics bridge is only supported on Windows.";
+    return std::nullopt;
+#endif
+}
+
+std::optional<AnalyticsSnapshot> AnalyticsBridge::smooth(
+    const AnalyticsSnapshot& snapshot, std::string& error
+) {
+    error.clear();
+    if (!smoother_available()) {
+        error = "EMA smoother unavailable.";
+        return std::nullopt;
+    }
+
+#ifdef _WIN32
+    using namespace detail;
+
+    // Lazy smoother creation (alpha=0.3)
+    if (impl_->smoother_handle == nullptr) {
+        aura_error_t c_error{};
+        const int status = impl_->smoother_create_fn(0.3, &impl_->smoother_handle, &c_error);
+        if (status != kStatusOk || impl_->smoother_handle == nullptr) {
+            error = aura_error_message(c_error, "Failed to create EMA smoother.");
+            return std::nullopt;
+        }
+    }
+
+    aura_snapshot_t c_raw = to_c_snapshot(snapshot);
+    aura_snapshot_t c_smoothed{};
+    aura_error_t c_error{};
+    const int status = impl_->smoother_update_fn(impl_->smoother_handle, &c_raw, &c_smoothed, &c_error);
+    if (status != kStatusOk) {
+        error = aura_error_message(c_error, "EMA smoother update failed.");
+        return std::nullopt;
+    }
+
+    return from_c_snapshot(c_smoothed);
+#else
+    error = "Analytics bridge is only supported on Windows.";
+    return std::nullopt;
+#endif
+}
+
+bool AnalyticsBridge::reset_smoother(std::string& error) {
+    error.clear();
+    if (!smoother_available()) {
+        error = "EMA smoother unavailable.";
+        return false;
+    }
+
+#ifdef _WIN32
+    using namespace detail;
+
+    if (impl_->smoother_handle == nullptr) {
+        return true;  // Nothing to reset
+    }
+
+    aura_error_t c_error{};
+    const int status = impl_->smoother_reset_fn(impl_->smoother_handle, &c_error);
+    if (status != kStatusOk) {
+        error = aura_error_message(c_error, "EMA smoother reset failed.");
+        return false;
+    }
+    return true;
+#else
+    error = "Analytics bridge is only supported on Windows.";
+    return false;
+#endif
+}
+
+bool AnalyticsBridge::evaluate_alerts(const AnalyticsSnapshot& snapshot, std::string& error) {
+    error.clear();
+    if (!alerts_available()) {
+        error = "Alert engine unavailable.";
+        return false;
+    }
+
+#ifdef _WIN32
+    using namespace detail;
+
+    // Lazy alert engine initialization
+    if (!impl_->alert_engine_initialized && impl_->alert_engine_handle == nullptr) {
+        aura_error_t init_error{};
+        const int init_status = impl_->alert_engine_create_fn(&impl_->alert_engine_handle, &init_error);
+        if (init_status == kStatusOk && impl_->alert_engine_handle != nullptr) {
+            auto add_rule = [&](int id, int metric, double threshold, double sustained, double cooldown, const char* name) {
+                aura_alert_rule_t rule{};
+                rule.id = id;
+                rule.metric = metric;
+                rule.comparator = AURA_COMPARATOR_ABOVE;
+                rule.threshold = threshold;
+                rule.sustained_seconds = sustained;
+                rule.cooldown_seconds = cooldown;
+                std::strncpy(rule.name, name, sizeof(rule.name) - 1);
+                aura_error_t rule_error{};
+                impl_->alert_engine_add_rule_fn(impl_->alert_engine_handle, &rule, &rule_error);
+            };
+
+            add_rule(1, AURA_METRIC_CPU_PERCENT,    90.0,  5.0, 30.0, "CPU High");
+            add_rule(2, AURA_METRIC_MEMORY_PERCENT,  85.0, 10.0, 30.0, "Memory High");
+            add_rule(3, AURA_METRIC_DISK_READ_BPS,   400.0 * 1024 * 1024, 3.0, 15.0, "Disk Read High");
+            add_rule(4, AURA_METRIC_NET_RECV_BPS,    80.0 * 1024 * 1024,  3.0, 15.0, "Network Recv High");
+            impl_->alert_engine_initialized = true;
+        }
+    }
+    if (impl_->alert_engine_handle == nullptr) {
+        error = "Failed to initialize alert engine.";
+        return false;
+    }
+
+    aura_snapshot_t c_snap = to_c_snapshot(snapshot);
+    aura_error_t c_error{};
+    const int status = impl_->alert_engine_evaluate_fn(impl_->alert_engine_handle, &c_snap, &c_error);
+    if (status != kStatusOk) {
+        error = aura_error_message(c_error, "Alert evaluation failed.");
+        return false;
+    }
+    return true;
+#else
+    error = "Analytics bridge is only supported on Windows.";
+    return false;
+#endif
+}
+
+std::vector<ActiveAlert> AnalyticsBridge::get_active_alerts(std::string& error) {
+    error.clear();
+    if (!alerts_available()) {
+        error = "Alert engine unavailable.";
+        return {};
+    }
+
+#ifdef _WIN32
+    using namespace detail;
+
+    if (impl_->alert_engine_handle == nullptr) {
+        return {};
+    }
+
+    constexpr int kMaxAlerts = 32;
+    aura_alert_status_t statuses[kMaxAlerts]{};
+    int count = 0;
+    aura_error_t c_error{};
+    const int status = impl_->alert_engine_get_active_fn(
+        impl_->alert_engine_handle, statuses, kMaxAlerts, &count, &c_error);
+    if (status != kStatusOk) {
+        error = aura_error_message(c_error, "Failed to get active alerts.");
+        return {};
+    }
+
+    std::vector<ActiveAlert> result;
+    result.reserve(static_cast<std::size_t>(count));
+    for (int i = 0; i < count; ++i) {
+        ActiveAlert alert;
+        alert.rule_id = statuses[i].rule_id;
+        alert.state = statuses[i].state;
+        alert.last_value = statuses[i].last_value;
+        alert.peak_value = statuses[i].peak_value;
+        alert.duration = statuses[i].duration;
+        alert.acknowledged = statuses[i].acknowledged != 0;
+        result.push_back(alert);
+    }
+    return result;
+#else
+    error = "Analytics bridge is only supported on Windows.";
+    return {};
+#endif
+}
+
+bool AnalyticsBridge::acknowledge_alert(const int rule_id, std::string& error) {
+    error.clear();
+    if (!alerts_available()) {
+        error = "Alert engine unavailable.";
+        return false;
+    }
+
+#ifdef _WIN32
+    using namespace detail;
+
+    if (impl_->alert_engine_handle == nullptr) {
+        error = "Alert engine not initialized.";
+        return false;
+    }
+
+    aura_error_t c_error{};
+    const int status = impl_->alert_engine_acknowledge_fn(impl_->alert_engine_handle, rule_id, &c_error);
+    if (status != kStatusOk) {
+        error = aura_error_message(c_error, "Failed to acknowledge alert.");
+        return false;
+    }
+    return true;
+#else
+    error = "Analytics bridge is only supported on Windows.";
+    return false;
+#endif
+}
+
+std::optional<DvrStatsResult> AnalyticsBridge::compute_dvr_stats(
+    void* store_handle, const double start, const double end, std::string& error
+) {
+    error.clear();
+    if (!dvr_stats_available()) {
+        error = "DVR stats computation unavailable.";
+        return std::nullopt;
+    }
+
+#ifdef _WIN32
+    using namespace detail;
+
+    if (store_handle == nullptr) {
+        error = "Store handle is null.";
+        return std::nullopt;
+    }
+
+    auto* store = static_cast<aura_store_t*>(store_handle);
+    const int has_start = (start > 0.0) ? 1 : 0;
+    const int has_end = (end > 0.0) ? 1 : 0;
+
+    aura_stats_result_t c_stats{};
+    aura_error_t c_error{};
+    const int status = impl_->dvr_compute_stats_fn(
+        store, has_start, start, has_end, end, &c_stats, &c_error);
+    if (status != kStatusOk) {
+        error = aura_error_message(c_error, "DVR stats computation failed.");
+        return std::nullopt;
+    }
+
+    DvrStatsResult result;
+    result.count = c_stats.count;
+    result.duration_seconds = c_stats.duration_seconds;
+    result.cpu = from_c_metric_stats(c_stats.cpu);
+    result.memory = from_c_metric_stats(c_stats.memory);
+    result.disk_read = from_c_metric_stats(c_stats.disk_read);
+    result.disk_write = from_c_metric_stats(c_stats.disk_write);
+    result.net_recv = from_c_metric_stats(c_stats.net_recv);
+    result.net_sent = from_c_metric_stats(c_stats.net_sent);
+    return result;
+#else
+    error = "Analytics bridge is only supported on Windows.";
+    return std::nullopt;
+#endif
+}
+
+bool AnalyticsBridge::export_json(
+    void* store_handle, const double start, const double end,
+    const bool include_stats, const std::string& path, std::string& error
+) {
+    error.clear();
+    if (!available()) {
+        error = "Analytics bridge unavailable.";
+        return false;
+    }
+
+#ifdef _WIN32
+    using namespace detail;
+
+    if (impl_->dvr_export_json_fn == nullptr) {
+        error = "DVR JSON export function unavailable.";
+        return false;
+    }
+    if (store_handle == nullptr) {
+        error = "Store handle is null.";
+        return false;
+    }
+
+    auto* store = static_cast<aura_store_t*>(store_handle);
+    const int has_start = (start > 0.0) ? 1 : 0;
+    const int has_end = (end > 0.0) ? 1 : 0;
+
+    aura_error_t c_error{};
+    const int status = impl_->dvr_export_json_fn(
+        store, has_start, start, has_end, end,
+        include_stats ? 1 : 0, path.c_str(), &c_error);
+    if (status != kStatusOk) {
+        error = aura_error_message(c_error, "DVR JSON export failed.");
+        return false;
+    }
+    return true;
+#else
+    error = "Analytics bridge is only supported on Windows.";
+    return false;
+#endif
+}
+
+bool AnalyticsBridge::export_csv(
+    void* store_handle, const double start, const double end,
+    const std::string& path, std::string& error
+) {
+    error.clear();
+    if (!available()) {
+        error = "Analytics bridge unavailable.";
+        return false;
+    }
+
+#ifdef _WIN32
+    using namespace detail;
+
+    if (impl_->dvr_export_csv_fn == nullptr) {
+        error = "DVR CSV export function unavailable.";
+        return false;
+    }
+    if (store_handle == nullptr) {
+        error = "Store handle is null.";
+        return false;
+    }
+
+    auto* store = static_cast<aura_store_t*>(store_handle);
+    const int has_start = (start > 0.0) ? 1 : 0;
+    const int has_end = (end > 0.0) ? 1 : 0;
+
+    aura_error_t c_error{};
+    const int status = impl_->dvr_export_csv_fn(
+        store, has_start, start, has_end, end, path.c_str(), &c_error);
+    if (status != kStatusOk) {
+        error = aura_error_message(c_error, "DVR CSV export failed.");
+        return false;
+    }
+    return true;
+#else
+    error = "Analytics bridge is only supported on Windows.";
+    return false;
+#endif
+}
+
+std::string AnalyticsBridge::loaded_path() const {
+    return impl_ != nullptr ? impl_->loaded_path : std::string{};
+}
+
+std::string AnalyticsBridge::load_error() const {
+    return impl_ != nullptr ? impl_->load_error : std::string{};
+}
+
+}  // namespace aura::shell

--- a/src/shell/native/src/aura_shell_window.cpp
+++ b/src/shell/native/src/aura_shell_window.cpp
@@ -22,6 +22,7 @@
 // ============================================================================
 
 #include "aura_shell/aura_shell_window.hpp"
+#include "aura_shell/analytics_bridge.hpp"
 #include "aura_shell/stylesheet_builder.hpp"
 #include "aura_shell/persistence_bridge.hpp"
 #include "aura_shell/render_bridge.hpp"
@@ -130,7 +131,8 @@ AuraShellWindow::AuraShellWindow(const LaunchConfig& config, QWidget* parent)
         std::make_unique<RenderBridge>(),
         std::make_unique<TimelineBridge>(),
         std::move(controller_config),
-        std::make_unique<PersistenceBridge>()
+        std::make_unique<PersistenceBridge>(),
+        std::make_unique<AnalyticsBridge>()
     );
 
     auto* root = new QWidget(this);

--- a/src/shell/native/src/aura_shell_window_refresh.cpp
+++ b/src/shell/native/src/aura_shell_window_refresh.cpp
@@ -174,6 +174,32 @@ void AuraShellWindow::refresh_cockpit() {
         }
         root->setProperty("thermalSensors", sensor_list);
 
+        // Health score
+        root->setProperty("healthAvailable", state.health.available);
+        root->setProperty("healthOverall", state.health.overall);
+        root->setProperty("healthCpu", state.health.cpu);
+        root->setProperty("healthMemory", state.health.memory);
+        root->setProperty("healthDisk", state.health.disk);
+        root->setProperty("healthNetwork", state.health.network);
+
+        // Trends (0=stable, 1=rising, 2=falling)
+        root->setProperty("cpuTrend", static_cast<int>(state.cpu_trend));
+        root->setProperty("memoryTrend", static_cast<int>(state.memory_trend));
+        root->setProperty("smoothingActive", state.smoothing_active);
+
+        // Active alerts as QVariantList
+        QVariantList alertList;
+        for (const auto& a : state.active_alerts) {
+            QVariantMap m;
+            m["ruleId"] = a.rule_id;
+            m["state"] = a.state;
+            m["peakValue"] = a.peak_value;
+            m["duration"] = a.duration;
+            m["acknowledged"] = a.acknowledged;
+            alertList.append(m);
+        }
+        root->setProperty("activeAlerts", alertList);
+
         if (theme_dirty_) {
             root->setProperty(
                 "themeMode",

--- a/src/shell/native/src/cockpit_controller.cpp
+++ b/src/shell/native/src/cockpit_controller.cpp
@@ -17,12 +17,14 @@ CockpitController::CockpitController(
     std::unique_ptr<IRenderBridge> render_bridge,
     std::unique_ptr<ITimelineBridge> timeline_bridge,
     Config config,
-    std::unique_ptr<IPersistenceBridge> persistence_bridge
+    std::unique_ptr<IPersistenceBridge> persistence_bridge,
+    std::unique_ptr<IAnalyticsBridge> analytics_bridge
 )
     : telemetry_bridge_(std::move(telemetry_bridge)),
       render_bridge_(std::move(render_bridge)),
       timeline_bridge_(std::move(timeline_bridge)),
       persistence_bridge_(std::move(persistence_bridge)),
+      analytics_bridge_(std::move(analytics_bridge)),
       config_(std::move(config)) {
     if (!std::isfinite(config_.poll_interval_seconds) || config_.poll_interval_seconds <= 0.0) {
         config_.poll_interval_seconds = 1.0;
@@ -42,6 +44,14 @@ CockpitController::CockpitController(
     if (config_.timeline_refresh_ticks == 0U) {
         config_.timeline_refresh_ticks = 1U;
     }
+    if (config_.snapshot_buffer_capacity == 0U) {
+        config_.snapshot_buffer_capacity = 60U;
+    }
+    if (config_.analytics_refresh_ticks == 0U) {
+        config_.analytics_refresh_ticks = 3U;
+    }
+    // Fire analytics on the very first tick
+    ticks_since_analytics_ = config_.analytics_refresh_ticks - 1U;
 
     if (persistence_bridge_ != nullptr && config_.persistence_enabled && config_.db_path.has_value()) {
         std::string persist_error;
@@ -279,6 +289,76 @@ CockpitUiState CockpitController::tick(
     }
     state.thermal = cached_thermal_;
 
+    // ── Analytics processing ───────────────────────────────────────────
+    if (analytics_bridge_ != nullptr && analytics_bridge_->available()) {
+        // Build analytics snapshot from current telemetry
+        AnalyticsSnapshot a_snap;
+        a_snap.timestamp = state.timestamp;
+        a_snap.cpu_percent = state.cpu_percent;
+        a_snap.memory_percent = state.memory_percent;
+        a_snap.disk_read_bps = state.disk_io.read_bytes_per_sec;
+        a_snap.disk_write_bps = state.disk_io.write_bytes_per_sec;
+        a_snap.net_recv_bps = state.network_io.recv_bytes_per_sec;
+        a_snap.net_sent_bps = state.network_io.sent_bytes_per_sec;
+
+        // Append to ring buffer (every tick)
+        snapshot_buffer_.push_back(a_snap);
+        if (snapshot_buffer_.size() > config_.snapshot_buffer_capacity) {
+            snapshot_buffer_.erase(snapshot_buffer_.begin());
+        }
+
+        // Smoothing (every tick, if enabled)
+        if (smoothing_enabled_ && analytics_bridge_->smoother_available()) {
+            std::string smooth_err;
+            auto smoothed = analytics_bridge_->smooth(a_snap, smooth_err);
+            if (smoothed.has_value()) {
+                state.cpu_percent = clamp_percent(smoothed->cpu_percent);
+                state.memory_percent = clamp_percent(smoothed->memory_percent);
+                state.smoothing_active = true;
+            }
+        }
+
+        // Alert evaluation (every tick)
+        if (analytics_bridge_->alerts_available()) {
+            std::string alert_err;
+            if (analytics_bridge_->evaluate_alerts(a_snap, alert_err)) {
+                state.active_alerts = analytics_bridge_->get_active_alerts(alert_err);
+            }
+        }
+
+        // Tiered analytics: health score + trends (every N ticks)
+        ++ticks_since_analytics_;
+        if (ticks_since_analytics_ >= config_.analytics_refresh_ticks) {
+            ticks_since_analytics_ = 0;
+
+            // Health score
+            if (analytics_bridge_->health_available()) {
+                std::string health_err;
+                auto health = analytics_bridge_->compute_health_score(a_snap, health_err);
+                if (health.has_value()) {
+                    state.health = *health;
+                }
+            }
+
+            // Trend detection (needs minimum 10 samples)
+            if (analytics_bridge_->trend_available() && snapshot_buffer_.size() >= 10U) {
+                std::string trend_err;
+
+                auto cpu_trend = analytics_bridge_->detect_trend(
+                    snapshot_buffer_, 0, config_.trend_sensitivity, trend_err);
+                if (cpu_trend.has_value()) {
+                    state.cpu_trend = cpu_trend->direction;
+                }
+
+                auto mem_trend = analytics_bridge_->detect_trend(
+                    snapshot_buffer_, 1, config_.trend_sensitivity, trend_err);
+                if (mem_trend.has_value()) {
+                    state.memory_trend = mem_trend->direction;
+                }
+            }
+        }
+    }
+
     populate_timeline_state(state, stream_error);
 
     state.status_line = fallback_status_line(stream_error);
@@ -313,6 +393,77 @@ CockpitUiState CockpitController::tick(
 
 const CockpitUiState& CockpitController::last_state() const {
     return last_state_;
+}
+
+void CockpitController::set_smoothing_enabled(const bool enabled) {
+    smoothing_enabled_ = enabled;
+    if (!enabled && analytics_bridge_ != nullptr) {
+        std::string err;
+        analytics_bridge_->reset_smoother(err);
+    }
+}
+
+bool CockpitController::smoothing_enabled() const {
+    return smoothing_enabled_;
+}
+
+bool CockpitController::acknowledge_alert(const int rule_id, std::string& error) {
+    if (analytics_bridge_ == nullptr) {
+        error = "Analytics bridge not available.";
+        return false;
+    }
+    return analytics_bridge_->acknowledge_alert(rule_id, error);
+}
+
+std::optional<DvrStatsResult> CockpitController::compute_dvr_stats(std::string& error) {
+    if (analytics_bridge_ == nullptr || !analytics_bridge_->dvr_stats_available()) {
+        error = "DVR stats not available.";
+        return std::nullopt;
+    }
+    if (persistence_bridge_ == nullptr) {
+        error = "Persistence bridge not available.";
+        return std::nullopt;
+    }
+    void* handle = persistence_bridge_->store_handle();
+    if (handle == nullptr) {
+        error = "Store not open.";
+        return std::nullopt;
+    }
+    return analytics_bridge_->compute_dvr_stats(handle, 0.0, 0.0, error);
+}
+
+bool CockpitController::export_dvr_json(const std::string& path, std::string& error) {
+    if (analytics_bridge_ == nullptr) {
+        error = "Analytics bridge not available.";
+        return false;
+    }
+    if (persistence_bridge_ == nullptr) {
+        error = "Persistence bridge not available.";
+        return false;
+    }
+    void* handle = persistence_bridge_->store_handle();
+    if (handle == nullptr) {
+        error = "Store not open.";
+        return false;
+    }
+    return analytics_bridge_->export_json(handle, 0.0, 0.0, true, path, error);
+}
+
+bool CockpitController::export_dvr_csv(const std::string& path, std::string& error) {
+    if (analytics_bridge_ == nullptr) {
+        error = "Analytics bridge not available.";
+        return false;
+    }
+    if (persistence_bridge_ == nullptr) {
+        error = "Persistence bridge not available.";
+        return false;
+    }
+    void* handle = persistence_bridge_->store_handle();
+    if (handle == nullptr) {
+        error = "Store not open.";
+        return false;
+    }
+    return analytics_bridge_->export_csv(handle, 0.0, 0.0, path, error);
 }
 
 }  // namespace aura::shell

--- a/src/shell/native/src/persistence_bridge.cpp
+++ b/src/shell/native/src/persistence_bridge.cpp
@@ -178,6 +178,14 @@ void PersistenceBridge::close_store() {
 #endif
 }
 
+void* PersistenceBridge::store_handle() const {
+#ifdef _WIN32
+    return impl_ != nullptr ? static_cast<void*>(impl_->open_store) : nullptr;
+#else
+    return nullptr;
+#endif
+}
+
 std::string PersistenceBridge::loaded_path() const {
     return impl_ != nullptr ? impl_->loaded_path : std::string{};
 }

--- a/tests/test_shell/CMakeLists.txt
+++ b/tests/test_shell/CMakeLists.txt
@@ -37,3 +37,9 @@ add_executable(aura_shell_ui_theme_tests
 )
 target_link_libraries(aura_shell_ui_theme_tests PRIVATE aura_shell_core)
 add_test(NAME aura_shell_ui_theme_tests COMMAND aura_shell_ui_theme_tests)
+
+add_executable(aura_shell_analytics_tests
+    native/analytics_bridge_tests.cpp
+)
+target_link_libraries(aura_shell_analytics_tests PRIVATE aura_shell_core)
+add_test(NAME aura_shell_analytics_tests COMMAND aura_shell_analytics_tests)

--- a/tests/test_shell/native/analytics_bridge_tests.cpp
+++ b/tests/test_shell/native/analytics_bridge_tests.cpp
@@ -1,0 +1,425 @@
+#include "cockpit_test_fakes.hpp"
+#include "cockpit_test_registry.hpp"
+
+#include "aura_shell/cockpit_controller.hpp"
+
+#include <cmath>
+#include <iostream>
+#include <memory>
+#include <string>
+
+// ---------------------------------------------------------------------------
+// 1. Health score flows through tick() → state.health
+// ---------------------------------------------------------------------------
+bool test_health_score_flows_through_tick() {
+    auto telemetry = std::make_unique<FakeTelemetryBridge>();
+    auto render = std::make_unique<FakeRenderBridge>();
+    auto timeline = std::make_unique<FakeTimelineBridge>();
+    auto analytics = std::make_unique<FakeAnalyticsBridge>();
+    analytics->next_health = {true, 82.0, 90.0, 75.0, 88.0, 95.0};
+
+    aura::shell::CockpitController::Config config;
+    config.analytics_refresh_ticks = 1;  // Every tick
+
+    aura::shell::CockpitController controller(
+        std::move(telemetry),
+        std::move(render),
+        std::move(timeline),
+        config,
+        nullptr,
+        std::move(analytics)
+    );
+    const auto state = controller.tick(1.0, 1700000000.0);
+
+    bool ok = true;
+    ok &= expect_true(state.health.available, "health-flow: available");
+    ok &= expect_true(std::abs(state.health.overall - 82.0) < 0.01, "health-flow: overall");
+    ok &= expect_true(std::abs(state.health.cpu - 90.0) < 0.01, "health-flow: cpu");
+    ok &= expect_true(std::abs(state.health.memory - 75.0) < 0.01, "health-flow: memory");
+    ok &= expect_true(std::abs(state.health.disk - 88.0) < 0.01, "health-flow: disk");
+    ok &= expect_true(std::abs(state.health.network - 95.0) < 0.01, "health-flow: network");
+    return ok;
+}
+
+// ---------------------------------------------------------------------------
+// 2. Health unavailable when no analytics bridge → defaults preserved
+// ---------------------------------------------------------------------------
+bool test_health_unavailable_preserves_defaults() {
+    auto telemetry = std::make_unique<FakeTelemetryBridge>();
+    auto render = std::make_unique<FakeRenderBridge>();
+    auto timeline = std::make_unique<FakeTimelineBridge>();
+    auto analytics = std::make_unique<FakeAnalyticsBridge>();
+    analytics->health_enabled = false;
+
+    aura::shell::CockpitController::Config config;
+    config.analytics_refresh_ticks = 1;
+
+    aura::shell::CockpitController controller(
+        std::move(telemetry),
+        std::move(render),
+        std::move(timeline),
+        config,
+        nullptr,
+        std::move(analytics)
+    );
+    const auto state = controller.tick(1.0, 1700000000.0);
+
+    bool ok = true;
+    ok &= expect_true(!state.health.available, "health-unavail: not available");
+    ok &= expect_true(std::abs(state.health.overall - 50.0) < 0.01, "health-unavail: default overall");
+    return ok;
+}
+
+// ---------------------------------------------------------------------------
+// 3. CPU trend rising with 10+ buffered samples
+// ---------------------------------------------------------------------------
+bool test_cpu_trend_rising_with_enough_samples() {
+    auto telemetry = std::make_unique<FakeTelemetryBridge>();
+    auto render = std::make_unique<FakeRenderBridge>();
+    auto timeline = std::make_unique<FakeTimelineBridge>();
+    auto analytics = std::make_unique<FakeAnalyticsBridge>();
+    analytics->next_cpu_trend = {aura::shell::TrendDirection::Rising, 1.5, 0.9};
+
+    aura::shell::CockpitController::Config config;
+    config.analytics_refresh_ticks = 1;
+    config.snapshot_buffer_capacity = 60;
+
+    aura::shell::CockpitController controller(
+        std::move(telemetry),
+        std::move(render),
+        std::move(timeline),
+        config,
+        nullptr,
+        std::move(analytics)
+    );
+
+    // Feed 10+ ticks to fill the buffer
+    for (int i = 0; i < 11; ++i) {
+        controller.tick(1.0, 1700000000.0 + i);
+    }
+    const auto state = controller.last_state();
+
+    bool ok = true;
+    ok &= expect_true(state.cpu_trend == aura::shell::TrendDirection::Rising, "trend-rising: cpu rising");
+    return ok;
+}
+
+// ---------------------------------------------------------------------------
+// 4. Trends need minimum 10 samples
+// ---------------------------------------------------------------------------
+bool test_trends_need_minimum_10_samples() {
+    auto telemetry = std::make_unique<FakeTelemetryBridge>();
+    auto render = std::make_unique<FakeRenderBridge>();
+    auto timeline = std::make_unique<FakeTimelineBridge>();
+    auto analytics = std::make_unique<FakeAnalyticsBridge>();
+    auto* analytics_ptr = analytics.get();
+    analytics->next_cpu_trend = {aura::shell::TrendDirection::Rising, 1.5, 0.9};
+
+    aura::shell::CockpitController::Config config;
+    config.analytics_refresh_ticks = 1;
+
+    aura::shell::CockpitController controller(
+        std::move(telemetry),
+        std::move(render),
+        std::move(timeline),
+        config,
+        nullptr,
+        std::move(analytics)
+    );
+
+    // Only 5 ticks — not enough for trends
+    for (int i = 0; i < 5; ++i) {
+        controller.tick(1.0, 1700000000.0 + i);
+    }
+
+    bool ok = true;
+    ok &= expect_true(analytics_ptr->trend_call_count == 0, "trend-min: no trend calls with <10 samples");
+    ok &= expect_true(controller.last_state().cpu_trend == aura::shell::TrendDirection::Stable, "trend-min: stable default");
+    return ok;
+}
+
+// ---------------------------------------------------------------------------
+// 5. Smoothing toggle affects displayed values
+// ---------------------------------------------------------------------------
+bool test_smoothing_toggle_affects_values() {
+    auto telemetry = std::make_unique<FakeTelemetryBridge>();
+    telemetry->next_snapshot = aura::shell::TelemetrySnapshot{50.0, 60.0};
+    auto render = std::make_unique<FakeRenderBridge>();
+    auto timeline = std::make_unique<FakeTimelineBridge>();
+    auto analytics = std::make_unique<FakeAnalyticsBridge>();
+    analytics->smoother_enabled = true;
+
+    aura::shell::CockpitController::Config config;
+
+    aura::shell::CockpitController controller(
+        std::move(telemetry),
+        std::move(render),
+        std::move(timeline),
+        config,
+        nullptr,
+        std::move(analytics)
+    );
+
+    // Without smoothing
+    auto state_off = controller.tick(1.0, 1700000000.0);
+    const double cpu_raw = state_off.cpu_percent;
+
+    // Enable smoothing
+    controller.set_smoothing_enabled(true);
+    auto state_on = controller.tick(1.0, 1700000001.0);
+
+    bool ok = true;
+    ok &= expect_true(state_on.smoothing_active, "smoothing-toggle: active flag");
+    // Smoothed value should differ from raw (fake applies 0.7x + 15)
+    ok &= expect_true(std::abs(state_on.cpu_percent - cpu_raw) > 0.01, "smoothing-toggle: value differs");
+    return ok;
+}
+
+// ---------------------------------------------------------------------------
+// 6. Smoothing off by default
+// ---------------------------------------------------------------------------
+bool test_smoothing_off_by_default() {
+    auto telemetry = std::make_unique<FakeTelemetryBridge>();
+    auto render = std::make_unique<FakeRenderBridge>();
+    auto timeline = std::make_unique<FakeTimelineBridge>();
+    auto analytics = std::make_unique<FakeAnalyticsBridge>();
+
+    aura::shell::CockpitController controller(
+        std::move(telemetry),
+        std::move(render),
+        std::move(timeline),
+        {},
+        nullptr,
+        std::move(analytics)
+    );
+
+    bool ok = true;
+    ok &= expect_true(!controller.smoothing_enabled(), "smoothing-default: disabled");
+    const auto state = controller.tick(1.0, 1700000000.0);
+    ok &= expect_true(!state.smoothing_active, "smoothing-default: state inactive");
+    return ok;
+}
+
+// ---------------------------------------------------------------------------
+// 7. Alert evaluation populates active_alerts
+// ---------------------------------------------------------------------------
+bool test_alert_evaluation_populates_active_alerts() {
+    auto telemetry = std::make_unique<FakeTelemetryBridge>();
+    auto render = std::make_unique<FakeRenderBridge>();
+    auto timeline = std::make_unique<FakeTimelineBridge>();
+    auto analytics = std::make_unique<FakeAnalyticsBridge>();
+    analytics->alerts_enabled = true;
+    analytics->next_alerts = {
+        {1, 2, 92.0, 95.0, 5.5, false},
+        {2, 1, 87.0, 88.0, 2.0, false},
+    };
+
+    aura::shell::CockpitController controller(
+        std::move(telemetry),
+        std::move(render),
+        std::move(timeline),
+        {},
+        nullptr,
+        std::move(analytics)
+    );
+    const auto state = controller.tick(1.0, 1700000000.0);
+
+    bool ok = true;
+    ok &= expect_true(state.active_alerts.size() == 2U, "alerts-populate: 2 alerts");
+    ok &= expect_true(state.active_alerts[0].rule_id == 1, "alerts-populate: first rule_id");
+    ok &= expect_true(state.active_alerts[0].state == 2, "alerts-populate: first state=triggered");
+    ok &= expect_true(std::abs(state.active_alerts[0].peak_value - 95.0) < 0.01, "alerts-populate: peak");
+    return ok;
+}
+
+// ---------------------------------------------------------------------------
+// 8. Alert acknowledge
+// ---------------------------------------------------------------------------
+bool test_alert_acknowledge() {
+    auto telemetry = std::make_unique<FakeTelemetryBridge>();
+    auto render = std::make_unique<FakeRenderBridge>();
+    auto timeline = std::make_unique<FakeTimelineBridge>();
+    auto analytics = std::make_unique<FakeAnalyticsBridge>();
+    analytics->alerts_enabled = true;
+    auto* analytics_ptr = analytics.get();
+
+    aura::shell::CockpitController controller(
+        std::move(telemetry),
+        std::move(render),
+        std::move(timeline),
+        {},
+        nullptr,
+        std::move(analytics)
+    );
+
+    std::string error;
+    const bool ack_ok = controller.acknowledge_alert(1, error);
+
+    bool ok = true;
+    ok &= expect_true(ack_ok, "alert-ack: success");
+    ok &= expect_true(analytics_ptr->last_acknowledged_rule_id == 1, "alert-ack: correct rule_id");
+    return ok;
+}
+
+// ---------------------------------------------------------------------------
+// 9. Analytics graceful degradation — rest of state unaffected
+// ---------------------------------------------------------------------------
+bool test_analytics_graceful_degradation() {
+    auto telemetry = std::make_unique<FakeTelemetryBridge>();
+    auto render = std::make_unique<FakeRenderBridge>();
+    auto timeline = std::make_unique<FakeTimelineBridge>();
+    auto analytics = std::make_unique<FakeAnalyticsBridge>();
+    analytics->backend_available = false;  // Analytics fully unavailable
+
+    aura::shell::CockpitController::Config config;
+    config.db_path = "C:/tmp/aura.db";
+
+    aura::shell::CockpitController controller(
+        std::move(telemetry),
+        std::move(render),
+        std::move(timeline),
+        config,
+        nullptr,
+        std::move(analytics)
+    );
+    const auto state = controller.tick(1.0, 1700000000.0);
+
+    bool ok = true;
+    // Core telemetry still works
+    ok &= expect_true(state.telemetry_available, "graceful-degrade: telemetry ok");
+    ok &= expect_true(state.render_available, "graceful-degrade: render ok");
+    // Analytics defaults
+    ok &= expect_true(!state.health.available, "graceful-degrade: health unavailable");
+    ok &= expect_true(state.cpu_trend == aura::shell::TrendDirection::Stable, "graceful-degrade: cpu stable");
+    ok &= expect_true(state.active_alerts.empty(), "graceful-degrade: no alerts");
+    ok &= expect_true(!state.smoothing_active, "graceful-degrade: no smoothing");
+    return ok;
+}
+
+// ---------------------------------------------------------------------------
+// 10. Tiered polling — health/trends update every N ticks
+// ---------------------------------------------------------------------------
+bool test_tiered_analytics_every_n_ticks() {
+    auto telemetry = std::make_unique<FakeTelemetryBridge>();
+    auto render = std::make_unique<FakeRenderBridge>();
+    auto timeline = std::make_unique<FakeTimelineBridge>();
+    auto analytics = std::make_unique<FakeAnalyticsBridge>();
+    auto* analytics_ptr = analytics.get();
+
+    aura::shell::CockpitController::Config config;
+    config.analytics_refresh_ticks = 3;
+    config.snapshot_buffer_capacity = 60;
+
+    aura::shell::CockpitController controller(
+        std::move(telemetry),
+        std::move(render),
+        std::move(timeline),
+        config,
+        nullptr,
+        std::move(analytics)
+    );
+
+    // Tick 1: analytics fires (first tick)
+    controller.tick(1.0, 1700000000.0);
+    const int after_1 = analytics_ptr->health_call_count;
+
+    // Tick 2,3: no analytics
+    controller.tick(1.0, 1700000001.0);
+    controller.tick(1.0, 1700000002.0);
+    const int after_3 = analytics_ptr->health_call_count;
+
+    // Tick 4: analytics fires again
+    controller.tick(1.0, 1700000003.0);
+    const int after_4 = analytics_ptr->health_call_count;
+
+    bool ok = true;
+    ok &= expect_true(after_1 == 1, "tiered: health called on tick 1");
+    ok &= expect_true(after_3 == 1, "tiered: health not called on tick 2-3");
+    ok &= expect_true(after_4 == 2, "tiered: health called on tick 4");
+    return ok;
+}
+
+// ---------------------------------------------------------------------------
+// 11. Snapshot buffer ring capped at capacity
+// ---------------------------------------------------------------------------
+bool test_snapshot_buffer_ring_capacity() {
+    auto telemetry = std::make_unique<FakeTelemetryBridge>();
+    auto render = std::make_unique<FakeRenderBridge>();
+    auto timeline = std::make_unique<FakeTimelineBridge>();
+    auto analytics = std::make_unique<FakeAnalyticsBridge>();
+    auto* analytics_ptr = analytics.get();
+
+    aura::shell::CockpitController::Config config;
+    config.snapshot_buffer_capacity = 5;
+    config.analytics_refresh_ticks = 1;
+
+    aura::shell::CockpitController controller(
+        std::move(telemetry),
+        std::move(render),
+        std::move(timeline),
+        config,
+        nullptr,
+        std::move(analytics)
+    );
+
+    // Feed 20 ticks — buffer should cap at 5
+    for (int i = 0; i < 20; ++i) {
+        controller.tick(1.0, 1700000000.0 + i);
+    }
+
+    // After 10+ ticks, trends should start being called (buffer hits 10 samples
+    // at tick 10, but our capacity is only 5 so we never reach 10)
+    bool ok = true;
+    ok &= expect_true(analytics_ptr->trend_call_count == 0, "ring-cap: no trend calls with capacity 5 < 10");
+    return ok;
+}
+
+// ---------------------------------------------------------------------------
+// 12. No analytics bridge → constructor and tick() work fine
+// ---------------------------------------------------------------------------
+bool test_no_analytics_bridge_works_fine() {
+    auto telemetry = std::make_unique<FakeTelemetryBridge>();
+    auto render = std::make_unique<FakeRenderBridge>();
+    auto timeline = std::make_unique<FakeTimelineBridge>();
+
+    aura::shell::CockpitController controller(
+        std::move(telemetry),
+        std::move(render),
+        std::move(timeline),
+        {},
+        nullptr,
+        nullptr  // no analytics bridge
+    );
+    const auto state = controller.tick(1.0, 1700000000.0);
+
+    bool ok = true;
+    ok &= expect_true(state.telemetry_available, "no-analytics: telemetry works");
+    ok &= expect_true(!state.health.available, "no-analytics: health defaults");
+    ok &= expect_true(state.cpu_trend == aura::shell::TrendDirection::Stable, "no-analytics: stable");
+    ok &= expect_true(state.active_alerts.empty(), "no-analytics: no alerts");
+    return ok;
+}
+
+int main() {
+    int failures = 0;
+
+    if (!test_health_score_flows_through_tick()) ++failures;
+    if (!test_health_unavailable_preserves_defaults()) ++failures;
+    if (!test_cpu_trend_rising_with_enough_samples()) ++failures;
+    if (!test_trends_need_minimum_10_samples()) ++failures;
+    if (!test_smoothing_toggle_affects_values()) ++failures;
+    if (!test_smoothing_off_by_default()) ++failures;
+    if (!test_alert_evaluation_populates_active_alerts()) ++failures;
+    if (!test_alert_acknowledge()) ++failures;
+    if (!test_analytics_graceful_degradation()) ++failures;
+    if (!test_tiered_analytics_every_n_ticks()) ++failures;
+    if (!test_snapshot_buffer_ring_capacity()) ++failures;
+    if (!test_no_analytics_bridge_works_fine()) ++failures;
+
+    if (failures == 0) {
+        std::cout << "All analytics bridge tests passed." << '\n';
+        return 0;
+    }
+    std::cerr << failures << " analytics bridge tests failed." << '\n';
+    return 1;
+}

--- a/tests/test_shell/native/cockpit_test_fakes.hpp
+++ b/tests/test_shell/native/cockpit_test_fakes.hpp
@@ -284,6 +284,130 @@ public:
     }
 };
 
+class FakePersistenceBridge final : public aura::shell::IPersistenceBridge {
+public:
+    bool backend_available = false;
+    bool store_opened = false;
+    void* fake_store_handle = nullptr;
+
+    bool available() const override { return backend_available; }
+
+    bool open_store(const std::string& /*db_path*/, double /*retention_seconds*/, std::string& error) override {
+        if (!backend_available) { error = "unavailable"; return false; }
+        store_opened = true;
+        return true;
+    }
+
+    bool append_snapshot(double /*ts*/, double /*cpu*/, double /*mem*/, double /*disk_r*/, double /*disk_w*/, std::string& error) override {
+        if (!backend_available) { error = "unavailable"; return false; }
+        return true;
+    }
+
+    void close_store() override { store_opened = false; }
+
+    void* store_handle() const override { return fake_store_handle; }
+};
+
+class FakeAnalyticsBridge final : public aura::shell::IAnalyticsBridge {
+public:
+    bool backend_available = true;
+    bool health_enabled = true;
+    bool trend_enabled = true;
+    bool smoother_enabled = false;
+    bool alerts_enabled = false;
+    bool dvr_stats_enabled = false;
+
+    aura::shell::HealthScoreState next_health{true, 75.0, 80.0, 70.0, 85.0, 90.0};
+    aura::shell::TrendResult next_cpu_trend{aura::shell::TrendDirection::Rising, 0.5, 0.8};
+    aura::shell::TrendResult next_mem_trend{aura::shell::TrendDirection::Stable, 0.0, 0.1};
+    aura::shell::AnalyticsSnapshot next_smoothed{};
+    std::vector<aura::shell::ActiveAlert> next_alerts;
+    aura::shell::DvrStatsResult next_dvr_stats;
+
+    int health_call_count = 0;
+    int trend_call_count = 0;
+    int smooth_call_count = 0;
+    int evaluate_call_count = 0;
+    int acknowledge_call_count = 0;
+    int last_acknowledged_rule_id = -1;
+
+    bool available() const override { return backend_available; }
+    bool smoother_available() const override { return backend_available && smoother_enabled; }
+    bool alerts_available() const override { return backend_available && alerts_enabled; }
+    bool health_available() const override { return backend_available && health_enabled; }
+    bool trend_available() const override { return backend_available && trend_enabled; }
+    bool dvr_stats_available() const override { return backend_available && dvr_stats_enabled; }
+
+    std::optional<aura::shell::HealthScoreState> compute_health_score(
+        const aura::shell::AnalyticsSnapshot& /*snapshot*/, std::string& error) override {
+        ++health_call_count;
+        if (!health_available()) { error = "health unavailable"; return std::nullopt; }
+        return next_health;
+    }
+
+    std::optional<aura::shell::TrendResult> detect_trend(
+        const std::vector<aura::shell::AnalyticsSnapshot>& /*snapshots*/,
+        int metric, double /*sensitivity*/, std::string& error) override {
+        ++trend_call_count;
+        if (!trend_available()) { error = "trend unavailable"; return std::nullopt; }
+        if (metric == 0) return next_cpu_trend;
+        if (metric == 1) return next_mem_trend;
+        error = "unknown metric";
+        return std::nullopt;
+    }
+
+    std::optional<aura::shell::AnalyticsSnapshot> smooth(
+        const aura::shell::AnalyticsSnapshot& snapshot, std::string& error) override {
+        ++smooth_call_count;
+        if (!smoother_available()) { error = "smoother unavailable"; return std::nullopt; }
+        next_smoothed = snapshot;
+        next_smoothed.cpu_percent = snapshot.cpu_percent * 0.5 + 10.0;
+        next_smoothed.memory_percent = snapshot.memory_percent * 0.5 + 10.0;
+        return next_smoothed;
+    }
+
+    bool reset_smoother(std::string& error) override {
+        if (!smoother_available()) { error = "smoother unavailable"; return false; }
+        return true;
+    }
+
+    bool evaluate_alerts(const aura::shell::AnalyticsSnapshot& /*snapshot*/, std::string& error) override {
+        ++evaluate_call_count;
+        if (!alerts_available()) { error = "alerts unavailable"; return false; }
+        return true;
+    }
+
+    std::vector<aura::shell::ActiveAlert> get_active_alerts(std::string& error) override {
+        if (!alerts_available()) { error = "alerts unavailable"; return {}; }
+        return next_alerts;
+    }
+
+    bool acknowledge_alert(int rule_id, std::string& error) override {
+        ++acknowledge_call_count;
+        if (!alerts_available()) { error = "alerts unavailable"; return false; }
+        last_acknowledged_rule_id = rule_id;
+        return true;
+    }
+
+    std::optional<aura::shell::DvrStatsResult> compute_dvr_stats(
+        void* /*store_handle*/, double /*start*/, double /*end*/, std::string& error) override {
+        if (!dvr_stats_available()) { error = "dvr stats unavailable"; return std::nullopt; }
+        return next_dvr_stats;
+    }
+
+    bool export_json(void* /*store_handle*/, double /*start*/, double /*end*/,
+        bool /*include_stats*/, const std::string& /*path*/, std::string& error) override {
+        if (!available()) { error = "unavailable"; return false; }
+        return true;
+    }
+
+    bool export_csv(void* /*store_handle*/, double /*start*/, double /*end*/,
+        const std::string& /*path*/, std::string& error) override {
+        if (!available()) { error = "unavailable"; return false; }
+        return true;
+    }
+};
+
 // ---------------------------------------------------------------------------
 // Assertion helpers
 // ---------------------------------------------------------------------------

--- a/tests/test_shell/native/cockpit_test_registry.hpp
+++ b/tests/test_shell/native/cockpit_test_registry.hpp
@@ -19,3 +19,17 @@ bool test_disk_network_rate_flows_through();
 bool test_tiered_polling_gpu_every_2_ticks();
 bool test_graceful_degradation_new_sensors();
 bool test_thermal_every_5_ticks();
+
+// Tests defined in analytics_bridge_tests.cpp (12 tests):
+bool test_health_score_flows_through_tick();
+bool test_health_unavailable_preserves_defaults();
+bool test_cpu_trend_rising_with_enough_samples();
+bool test_trends_need_minimum_10_samples();
+bool test_smoothing_toggle_affects_values();
+bool test_smoothing_off_by_default();
+bool test_alert_evaluation_populates_active_alerts();
+bool test_alert_acknowledge();
+bool test_analytics_graceful_degradation();
+bool test_tiered_analytics_every_n_ticks();
+bool test_snapshot_buffer_ring_capacity();
+bool test_no_analytics_bridge_works_fine();


### PR DESCRIPTION
## Summary

- **AnalyticsBridge** — new DLL bridge (Pimpl pattern, same `LoadLibraryW`/`GetProcAddress` approach as `PersistenceBridge`) that loads 16 function pointers from `aura_platform.dll` for health score, trend detection, EMA smoother, alert engine, DVR stats, and JSON/CSV export
- **CockpitController** — analytics processing in `tick()`: snapshot ring buffer, optional EMA smoothing, alert evaluation every tick; health score + trend detection every N ticks (tiered polling, default 3)
- **CockpitScene.qml** — 4th health gauge with inverted color scale (high=green, low=red), sub-score pills (CPU/MEM/DISK/NET), trend direction arrows (↑↓→) on CPU and MEM gauges, alert count badge with pulsing red animation
- **TimelineScene.qml** — STATS toggle pill with CPU/MEM statistics overlay (avg, p95, max, σ), EXPORT pill that sets a property for C++ to trigger DVR JSON export
- **12 new tests** covering health flow, trend thresholds, smoothing toggle, alert evaluation, graceful degradation, tiered polling, ring buffer capacity, and null-bridge safety

All existing 15 cockpit tests + 12 new analytics tests pass. GUI compiles and launches. Analytics degrade gracefully when `aura_platform.dll` is absent.

## Test plan

- [x] `.\aura.cmd test shell` — all 27 tests pass (5 suites)
- [x] `.\aura.cmd build gui` — compiles without errors
- [ ] `.\aura.cmd gui` — health gauge visible, trend arrows on CPU/MEM gauges
- [ ] Graceful degradation: rename `aura_platform.dll` → GUI launches without analytics

🤖 Generated with [Claude Code](https://claude.com/claude-code)