### PR TITLE
fix(shell): UX overhaul — resizable panels, stable health, native resize

### DIFF
--- a/src/shell/native/include/aura_shell/aura_shell_window.hpp
+++ b/src/shell/native/include/aura_shell/aura_shell_window.hpp
@@ -8,6 +8,7 @@
 #include <QPushButton>
 #include <QQuickWidget>
 #include <QSettings>
+#include <QSplitter>
 #include <QStackedWidget>
 #include <QTabBar>
 #include <QTimer>
@@ -63,12 +64,10 @@ private:
 
     // --- Core methods (aura_shell_window.cpp) ---
     SlotWidgets build_slot(DockSlot slot, QWidget* parent);
-    Qt::Edges hit_test_edge(const QPoint& pos) const;
     void sync_theme_to_qml();
     void apply_theme(UiThemeMode mode, bool persist);
 
     // --- Constants ---
-    static constexpr int kResizeBorder = 14;
     static constexpr const char* k_theme_mode_setting_key = "ui/theme_mode";
 
     // --- Member data ---
@@ -78,6 +77,7 @@ private:
     SizeCategory current_size_category_{SizeCategory::Regular};
     SizeMetrics current_metrics_{metrics_for_category(SizeCategory::Regular)};
     QWidget* body_{nullptr};
+    QSplitter* splitter_{nullptr};
     double current_interval_seconds_{1.0};
     std::unique_ptr<CockpitController> controller_;
     DockState dock_state_{build_default_dock_state()};
@@ -117,7 +117,6 @@ private:
     std::array<QLabel*, 5> panel_title_labels_{};
     bool dragging_{false};
     QPoint drag_origin_{};
-    Qt::Edges resize_edge_{};
 };
 
 }  // namespace aura::shell

--- a/src/shell/native/include/aura_shell/cockpit_controller.hpp
+++ b/src/shell/native/include/aura_shell/cockpit_controller.hpp
@@ -101,6 +101,12 @@ private:
     std::vector<AnalyticsSnapshot> snapshot_buffer_;
     std::size_t ticks_since_analytics_{0};
     bool smoothing_enabled_{false};
+
+    // Cached analytics results — persisted across non-analytics ticks
+    HealthScoreState cached_health_;
+    TrendDirection cached_cpu_trend_{TrendDirection::Stable};
+    TrendDirection cached_memory_trend_{TrendDirection::Stable};
+    std::vector<ActiveAlert> cached_alerts_;
 };
 
 }  // namespace aura::shell

--- a/src/shell/native/qml/TimelineScene.qml
+++ b/src/shell/native/qml/TimelineScene.qml
@@ -42,6 +42,11 @@ Rectangle {
     property bool exportRequested: false
     property string exportStatus: ""
 
+    // ── Legend toggle state ───────────────────────────────────────────────
+    property bool showCpu: true
+    property bool showMem: true
+    property bool showGpu: true
+
     readonly property bool pinkMode: themeMode === "pink_cute"
     readonly property bool hasData: timelinePoints.length >= 2
 
@@ -73,10 +78,13 @@ Rectangle {
     readonly property var gpuStrokeColor: pinkMode
         ? [1.0, 0.690, 0.533, 0.75] : [0.961, 0.620, 0.043, 0.65]
 
-    // ── Trigger repaint on data or theme change ──────────────────────────────
+    // ── Trigger repaint on data, theme, or visibility change ─────────────────
     onTimelinePointsChanged: chartCanvas.requestPaint()
     onThemeModeChanged: chartCanvas.requestPaint()
     onGpuAvailableChanged: chartCanvas.requestPaint()
+    onShowCpuChanged: chartCanvas.requestPaint()
+    onShowMemChanged: chartCanvas.requestPaint()
+    onShowGpuChanged: chartCanvas.requestPaint()
 
     // ── Background gradient ──────────────────────────────────────────────────
     Rectangle {
@@ -120,7 +128,7 @@ Rectangle {
         }
     }
 
-    // ── Legend pills (top-right) ─────────────────────────────────────────────
+    // ── Legend pills (top-right) — click to toggle series ───────────────────
     Row {
         anchors.right: parent.right
         anchors.top: parent.top
@@ -132,20 +140,27 @@ Rectangle {
         Repeater {
             model: {
                 var items = [
-                    { label: "CPU", sc: root.cpuStrokeColor },
-                    { label: "MEM", sc: root.memStrokeColor }
+                    { label: "CPU", sc: root.cpuStrokeColor, key: "cpu" },
+                    { label: "MEM", sc: root.memStrokeColor, key: "mem" }
                 ]
                 if (root.gpuAvailable)
-                    items.push({ label: "GPU", sc: root.gpuStrokeColor })
+                    items.push({ label: "GPU", sc: root.gpuStrokeColor, key: "gpu" })
                 return items
             }
             Rectangle {
+                property bool seriesVisible: modelData.key === "cpu" ? root.showCpu
+                                           : modelData.key === "mem" ? root.showMem
+                                           : root.showGpu
                 width: pillText.implicitWidth + badgeSize * 1.2
                 height: pillText.implicitHeight + badgeSize * 0.5
                 radius: height * 0.3
-                color: "transparent"
+                color: seriesVisible
+                    ? Qt.rgba(modelData.sc[0], modelData.sc[1], modelData.sc[2], 0.15)
+                    : "transparent"
                 border.width: 1
-                border.color: Qt.rgba(modelData.sc[0], modelData.sc[1], modelData.sc[2], modelData.sc[3] * 0.7)
+                border.color: Qt.rgba(modelData.sc[0], modelData.sc[1], modelData.sc[2],
+                    seriesVisible ? modelData.sc[3] * 0.7 : 0.20)
+                opacity: seriesVisible ? 1.0 : 0.45
 
                 Text {
                     id: pillText
@@ -156,6 +171,16 @@ Rectangle {
                     font.weight: Font.DemiBold
                     font.letterSpacing: 1
                     font.family: "Segoe UI"
+                }
+
+                MouseArea {
+                    anchors.fill: parent
+                    cursorShape: Qt.PointingHandCursor
+                    onClicked: {
+                        if (modelData.key === "cpu") root.showCpu = !root.showCpu
+                        else if (modelData.key === "mem") root.showMem = !root.showMem
+                        else root.showGpu = !root.showGpu
+                    }
                 }
             }
         }
@@ -431,17 +456,19 @@ Rectangle {
                 ctx.fill()
             }
 
-            // ── Draw series back-to-front ──
+            // ── Draw series back-to-front (respecting toggle state) ──
 
             // 1. Memory (teal — furthest back)
             var mc = root.memStrokeColor
-            var memFill = root.pinkMode
-                ? [[0.0, Qt.rgba(0.431, 0.906, 0.718, 0.22)], [1.0, Qt.rgba(0.431, 0.906, 0.718, 0.01)]]
-                : [[0.0, Qt.rgba(0.20, 0.70, 0.65, 0.20)], [1.0, Qt.rgba(0.20, 0.70, 0.65, 0.01)]]
-            drawSeries(memPts, memFill, mc)
+            if (root.showMem) {
+                var memFill = root.pinkMode
+                    ? [[0.0, Qt.rgba(0.431, 0.906, 0.718, 0.22)], [1.0, Qt.rgba(0.431, 0.906, 0.718, 0.01)]]
+                    : [[0.0, Qt.rgba(0.20, 0.70, 0.65, 0.20)], [1.0, Qt.rgba(0.20, 0.70, 0.65, 0.01)]]
+                drawSeries(memPts, memFill, mc)
+            }
 
-            // 2. GPU (gold — middle layer, only if available)
-            if (gpuPts !== null) {
+            // 2. GPU (gold — middle layer, only if available and visible)
+            if (gpuPts !== null && root.showGpu) {
                 var gc = root.gpuStrokeColor
                 var gpuFill = root.pinkMode
                     ? [[0.0, Qt.rgba(1.0, 0.690, 0.533, 0.20)], [1.0, Qt.rgba(1.0, 0.690, 0.533, 0.01)]]
@@ -451,19 +478,23 @@ Rectangle {
 
             // 3. CPU (accent — front, most prominent)
             var cc = root.cpuStrokeColor
-            var cpuFill = root.pinkMode
-                ? [[0.0, Qt.rgba(0.753, 0.518, 0.988, 0.28)],
-                   [0.5, Qt.rgba(1.0, 0.302, 0.651, 0.15)],
-                   [1.0, Qt.rgba(1.0, 0.690, 0.533, 0.01)]]
-                : [[0.0, Qt.rgba(accentRed, accentGreen, accentBlue, 0.26)],
-                   [1.0, Qt.rgba(accentRed, accentGreen, accentBlue, 0.01)]]
-            drawSeries(cpuPts, cpuFill, cc)
+            if (root.showCpu) {
+                var cpuFill = root.pinkMode
+                    ? [[0.0, Qt.rgba(0.753, 0.518, 0.988, 0.28)],
+                       [0.5, Qt.rgba(1.0, 0.302, 0.651, 0.15)],
+                       [1.0, Qt.rgba(1.0, 0.690, 0.533, 0.01)]]
+                    : [[0.0, Qt.rgba(accentRed, accentGreen, accentBlue, 0.26)],
+                       [1.0, Qt.rgba(accentRed, accentGreen, accentBlue, 0.01)]]
+                drawSeries(cpuPts, cpuFill, cc)
+            }
 
             // ── Glow dots at latest values ──
-            drawGlowDot(memPts[n - 1], mc)
-            if (gpuPts !== null)
+            if (root.showMem)
+                drawGlowDot(memPts[n - 1], mc)
+            if (gpuPts !== null && root.showGpu)
                 drawGlowDot(gpuPts[n - 1], gc)
-            drawGlowDot(cpuPts[n - 1], cc)
+            if (root.showCpu)
+                drawGlowDot(cpuPts[n - 1], cc)
         }
     }
 

--- a/src/shell/native/src/aura_shell_window.cpp
+++ b/src/shell/native/src/aura_shell_window.cpp
@@ -43,6 +43,7 @@
 #include <QQuickWidget>
 #include <QScreen>
 #include <QSizePolicy>
+#include <QSplitter>
 #include <QStackedWidget>
 #include <QTabBar>
 #include <QTimer>
@@ -215,27 +216,34 @@ AuraShellWindow::AuraShellWindow(const LaunchConfig& config, QWidget* parent)
     root_layout->addWidget(titlebar_);
 
     // ---------------------------------------------------------------
-    // Main body — three dock slots
+    // Main body — three dock slots with resizable splitter
     // ---------------------------------------------------------------
     body_ = new QWidget(root);
     body_->setAutoFillBackground(false);
-    auto* body_layout = new QHBoxLayout(body_);
+    auto* body_layout = new QVBoxLayout(body_);
     body_layout->setContentsMargins(
         current_metrics_.body_margin, current_metrics_.body_margin,
         current_metrics_.body_margin, current_metrics_.body_margin);
-    body_layout->setSpacing(current_metrics_.body_spacing);
+    body_layout->setSpacing(0);
+
+    splitter_ = new QSplitter(Qt::Horizontal, body_);
+    splitter_->setHandleWidth(current_metrics_.body_spacing > 0 ? current_metrics_.body_spacing : 6);
+    splitter_->setChildrenCollapsible(false);
 
     for (const auto slot : all_dock_slots()) {
         const std::size_t index = slot_index(slot);
-        slot_widgets_[index] = build_slot(slot, body_);
+        slot_widgets_[index] = build_slot(slot, splitter_);
         connect(slot_widgets_[index].tab_bar, &QTabBar::currentChanged, this, [this, slot](const int tab_index) {
             on_tab_changed(slot, tab_index);
         });
-        body_layout->addWidget(
-            slot_widgets_[index].frame,
-            slot == DockSlot::Center ? 3 : 1
-        );
+        splitter_->addWidget(slot_widgets_[index].frame);
     }
+
+    // Set initial sizes proportional to 1:3:1
+    const int total_w = width() - 2 * current_metrics_.body_margin;
+    splitter_->setSizes({total_w / 5, total_w * 3 / 5, total_w / 5});
+
+    body_layout->addWidget(splitter_, 1);
 
     build_panel_pages();
     rebuild_dock_slots();
@@ -269,8 +277,8 @@ AuraShellWindow::AuraShellWindow(const LaunchConfig& config, QWidget* parent)
     apply_theme(current_theme_mode_, false);
     refresh_cockpit();
 
-    // Install app-level event filter so edge resize works even over child widgets
-    qApp->installEventFilter(this);
+    // Note: titlebar event filter already installed above for drag handling.
+    // Window resize is handled natively via WM_NCHITTEST — no Qt-level filter needed.
 }
 
 #ifdef _WIN32
@@ -321,35 +329,7 @@ bool AuraShellWindow::nativeEvent(const QByteArray& /*eventType*/, void* message
 #endif
 
 bool AuraShellWindow::eventFilter(QObject* watched, QEvent* event) {
-    // Intercept mouse events from ANY child widget near window edges for resize
-    if (!isMaximized() && event->type() == QEvent::MouseButtonPress) {
-        auto* me = static_cast<QMouseEvent*>(event);
-        if (me->button() == Qt::LeftButton) {
-            const QPoint win_pos = mapFromGlobal(me->globalPosition().toPoint());
-            const Qt::Edges edges = hit_test_edge(win_pos);
-            if (edges != Qt::Edges{} && windowHandle()) {
-                windowHandle()->startSystemResize(edges);
-                return true;
-            }
-        }
-    }
-    if (!isMaximized() && event->type() == QEvent::MouseMove) {
-        auto* me = static_cast<QMouseEvent*>(event);
-        const QPoint win_pos = mapFromGlobal(me->globalPosition().toPoint());
-        const Qt::Edges edge = hit_test_edge(win_pos);
-        if (edge == (Qt::LeftEdge | Qt::TopEdge) || edge == (Qt::RightEdge | Qt::BottomEdge))
-            setCursor(Qt::SizeFDiagCursor);
-        else if (edge == (Qt::RightEdge | Qt::TopEdge) || edge == (Qt::LeftEdge | Qt::BottomEdge))
-            setCursor(Qt::SizeBDiagCursor);
-        else if (edge & (Qt::LeftEdge | Qt::RightEdge))
-            setCursor(Qt::SizeHorCursor);
-        else if (edge & (Qt::TopEdge | Qt::BottomEdge))
-            setCursor(Qt::SizeVerCursor);
-        else
-            unsetCursor();
-    }
-
-    // Titlebar drag + double-click
+    // Titlebar drag + double-click (resize is handled natively via WM_NCHITTEST)
     if (watched == titlebar_) {
         if (event->type() == QEvent::MouseButtonPress) {
             auto* mouse_event = static_cast<QMouseEvent*>(event);
@@ -379,35 +359,10 @@ bool AuraShellWindow::eventFilter(QObject* watched, QEvent* event) {
 }
 
 void AuraShellWindow::mousePressEvent(QMouseEvent* event) {
-    if (event->button() == Qt::LeftButton && !isMaximized()) {
-        const Qt::Edges edges = hit_test_edge(event->pos());
-        if (edges != Qt::Edges{}) {
-            // Use native OS resize — works even when child widgets eat events
-            if (windowHandle()) {
-                windowHandle()->startSystemResize(edges);
-            }
-            event->accept();
-            return;
-        }
-    }
     QMainWindow::mousePressEvent(event);
 }
 
 void AuraShellWindow::mouseMoveEvent(QMouseEvent* event) {
-    // Update cursor shape on hover near edges
-    if (!isMaximized()) {
-        const Qt::Edges edge = hit_test_edge(event->pos());
-        if (edge == (Qt::LeftEdge | Qt::TopEdge) || edge == (Qt::RightEdge | Qt::BottomEdge))
-            setCursor(Qt::SizeFDiagCursor);
-        else if (edge == (Qt::RightEdge | Qt::TopEdge) || edge == (Qt::LeftEdge | Qt::BottomEdge))
-            setCursor(Qt::SizeBDiagCursor);
-        else if (edge & (Qt::LeftEdge | Qt::RightEdge))
-            setCursor(Qt::SizeHorCursor);
-        else if (edge & (Qt::TopEdge | Qt::BottomEdge))
-            setCursor(Qt::SizeVerCursor);
-        else
-            unsetCursor();
-    }
     QMainWindow::mouseMoveEvent(event);
 }
 
@@ -422,13 +377,14 @@ void AuraShellWindow::resizeEvent(QResizeEvent* event) {
         current_size_category_ = new_cat;
         current_metrics_ = metrics_for_category(new_cat);
         setStyleSheet(build_app_stylesheet(current_theme_mode_, current_metrics_));
-        if (body_ != nullptr) {
-            if (auto* bl = body_->layout()) {
-                bl->setContentsMargins(
-                    current_metrics_.body_margin, current_metrics_.body_margin,
-                    current_metrics_.body_margin, current_metrics_.body_margin);
-                bl->setSpacing(current_metrics_.body_spacing);
-            }
+        if (body_ != nullptr && body_->layout() != nullptr) {
+            body_->layout()->setContentsMargins(
+                current_metrics_.body_margin, current_metrics_.body_margin,
+                current_metrics_.body_margin, current_metrics_.body_margin);
+        }
+        if (splitter_ != nullptr) {
+            splitter_->setHandleWidth(
+                current_metrics_.body_spacing > 0 ? current_metrics_.body_spacing : 6);
         }
         // Update slot internal padding to match new category
         for (const auto slot : all_dock_slots()) {
@@ -440,15 +396,6 @@ void AuraShellWindow::resizeEvent(QResizeEvent* event) {
             }
         }
     }
-}
-
-Qt::Edges AuraShellWindow::hit_test_edge(const QPoint& pos) const {
-    Qt::Edges edges;
-    if (pos.x() < kResizeBorder)                edges |= Qt::LeftEdge;
-    if (pos.x() >= width() - kResizeBorder)     edges |= Qt::RightEdge;
-    if (pos.y() < kResizeBorder)                edges |= Qt::TopEdge;
-    if (pos.y() >= height() - kResizeBorder)    edges |= Qt::BottomEdge;
-    return edges;
 }
 
 void AuraShellWindow::sync_theme_to_qml() {
@@ -555,11 +502,11 @@ SlotWidgets AuraShellWindow::build_slot(const DockSlot slot, QWidget* parent) {
     zone_label->setObjectName("slotZoneLabel");
     zone_label->setContentsMargins(12, 0, 0, 2);
 
-    // Tab bar sits flush below the zone label
+    // Tab bar sits flush below the zone label — movable for reordering
     auto* tab_bar = new QTabBar(frame);
     tab_bar->setDocumentMode(true);
     tab_bar->setExpanding(false);
-    tab_bar->setMovable(false);
+    tab_bar->setMovable(true);
     tab_bar->setUsesScrollButtons(true);
     tab_bar->setDrawBase(false);
     tab_bar->setContentsMargins(8, 0, 8, 0);

--- a/src/shell/native/src/cockpit_controller.cpp
+++ b/src/shell/native/src/cockpit_controller.cpp
@@ -322,7 +322,7 @@ CockpitUiState CockpitController::tick(
         if (analytics_bridge_->alerts_available()) {
             std::string alert_err;
             if (analytics_bridge_->evaluate_alerts(a_snap, alert_err)) {
-                state.active_alerts = analytics_bridge_->get_active_alerts(alert_err);
+                cached_alerts_ = analytics_bridge_->get_active_alerts(alert_err);
             }
         }
 
@@ -336,7 +336,7 @@ CockpitUiState CockpitController::tick(
                 std::string health_err;
                 auto health = analytics_bridge_->compute_health_score(a_snap, health_err);
                 if (health.has_value()) {
-                    state.health = *health;
+                    cached_health_ = *health;
                 }
             }
 
@@ -347,16 +347,22 @@ CockpitUiState CockpitController::tick(
                 auto cpu_trend = analytics_bridge_->detect_trend(
                     snapshot_buffer_, 0, config_.trend_sensitivity, trend_err);
                 if (cpu_trend.has_value()) {
-                    state.cpu_trend = cpu_trend->direction;
+                    cached_cpu_trend_ = cpu_trend->direction;
                 }
 
                 auto mem_trend = analytics_bridge_->detect_trend(
                     snapshot_buffer_, 1, config_.trend_sensitivity, trend_err);
                 if (mem_trend.has_value()) {
-                    state.memory_trend = mem_trend->direction;
+                    cached_memory_trend_ = mem_trend->direction;
                 }
             }
         }
+
+        // Always apply cached analytics results (stable between refresh ticks)
+        state.health = cached_health_;
+        state.cpu_trend = cached_cpu_trend_;
+        state.memory_trend = cached_memory_trend_;
+        state.active_alerts = cached_alerts_;
     }
 
     populate_timeline_state(state, stream_error);

--- a/src/shell/native/src/dock_model.cpp
+++ b/src/shell/native/src/dock_model.cpp
@@ -41,11 +41,10 @@ std::array<DockSlot, 3> all_dock_slots() {
 DockState build_default_dock_state() {
     DockState state;
     state.slot_tabs[slot_index(DockSlot::Left)] = {PanelId::TelemetryOverview};
-    state.slot_tabs[slot_index(DockSlot::Center)] = {PanelId::RenderSurface};
+    state.slot_tabs[slot_index(DockSlot::Center)] = {PanelId::RenderSurface, PanelId::DvrTimeline};
     state.slot_tabs[slot_index(DockSlot::Right)] = {
-        PanelId::TopProcesses,
-        PanelId::DvrTimeline,
         PanelId::ProcessPanel,
+        PanelId::TopProcesses,
     };
     state.active_tab = {0U, 0U, 0U};
     return state;

--- a/src/shell/native/src/stylesheet_builder.cpp
+++ b/src/shell/native/src/stylesheet_builder.cpp
@@ -291,6 +291,18 @@ QString build_app_stylesheet(const UiThemeMode mode, const SizeMetrics& m) {
         "    margin-left: 12px;"
         "    margin-bottom: 4px;"
         "}"
+        // --- Splitter handles ---
+        "QSplitter::handle {"
+        "    background: ${BORDER_SUBTLE};"
+        "    border-radius: 2px;"
+        "    margin: 40px 0px;"
+        "}"
+        "QSplitter::handle:hover {"
+        "    background: ${ACCENT};"
+        "}"
+        "QSplitter::handle:pressed {"
+        "    background: ${ACCENT_HOVER};"
+        "}"
         // --- Scrollbars ---
         "QScrollBar:vertical {"
         "    background: ${BG_WINDOW};"

--- a/tests/test_shell/native/dock_model_invariant_tests.cpp
+++ b/tests/test_shell/native/dock_model_invariant_tests.cpp
@@ -103,8 +103,8 @@ void test_move_out_of_range_index_throws() {
     using aura::shell::PanelMoveRequest;
 
     const auto state = aura::shell::build_default_dock_state();
-    // Right has 3 panels (TopProcesses, DvrTimeline, ProcessPanel).
-    // Valid to_index values are 0, 1, 2, 3 (append). Index 10 is out of range.
+    // Right has 2 panels (ProcessPanel, TopProcesses).
+    // Valid to_index values are 0, 1, 2 (append). Index 10 is out of range.
     bool threw = false;
     try {
         static_cast<void>(aura::shell::move_panel(
@@ -130,12 +130,20 @@ void test_set_active_tab_zero_on_empty_slot_allowed() {
     using aura::shell::PanelId;
     using aura::shell::PanelMoveRequest;
 
-    // Create a state where Center has no panels (move RenderSurface out)
+    // Create a state where Center has no panels (move both RenderSurface and DvrTimeline out)
     const auto state = aura::shell::build_default_dock_state();
-    const auto empty_state = aura::shell::move_panel(
+    auto intermediate = aura::shell::move_panel(
         state,
         PanelMoveRequest{
             .panel_id = PanelId::RenderSurface,
+            .to_slot = DockSlot::Right,
+            .to_index = std::nullopt,
+        }
+    );
+    const auto empty_state = aura::shell::move_panel(
+        intermediate,
+        PanelMoveRequest{
+            .panel_id = PanelId::DvrTimeline,
             .to_slot = DockSlot::Right,
             .to_index = std::nullopt,
         }
@@ -164,10 +172,10 @@ void test_move_nullopt_index_appends_to_end() {
     using aura::shell::PanelId;
     using aura::shell::PanelMoveRequest;
 
-    // Default: Right={TopProcesses[0], DvrTimeline[1], ProcessPanel[2]}
+    // Default: Right={ProcessPanel[0], TopProcesses[1]}
     const auto state = aura::shell::build_default_dock_state();
 
-    // Move TelemetryOverview to Right with nullopt -> should be appended at index 3
+    // Move TelemetryOverview to Right with nullopt -> should be appended at index 2
     const auto moved = aura::shell::move_panel(
         state,
         PanelMoveRequest{
@@ -177,15 +185,14 @@ void test_move_nullopt_index_appends_to_end() {
         }
     );
 
-    // Right now has 4 panels: {TopProcesses, DvrTimeline, ProcessPanel, TelemetryOverview}
-    assert(moved.slot_tabs[slot_index(DockSlot::Right)].size() == 4U);
-    assert(moved.slot_tabs[slot_index(DockSlot::Right)][0] == PanelId::TopProcesses);
-    assert(moved.slot_tabs[slot_index(DockSlot::Right)][1] == PanelId::DvrTimeline);
-    assert(moved.slot_tabs[slot_index(DockSlot::Right)][2] == PanelId::ProcessPanel);
-    assert(moved.slot_tabs[slot_index(DockSlot::Right)][3] == PanelId::TelemetryOverview);
+    // Right now has 3 panels: {ProcessPanel, TopProcesses, TelemetryOverview}
+    assert(moved.slot_tabs[slot_index(DockSlot::Right)].size() == 3U);
+    assert(moved.slot_tabs[slot_index(DockSlot::Right)][0] == PanelId::ProcessPanel);
+    assert(moved.slot_tabs[slot_index(DockSlot::Right)][1] == PanelId::TopProcesses);
+    assert(moved.slot_tabs[slot_index(DockSlot::Right)][2] == PanelId::TelemetryOverview);
 
-    // Destination active_tab should point to the newly inserted panel at index 3
-    assert(moved.active_tab[slot_index(DockSlot::Right)] == 3U);
+    // Destination active_tab should point to the newly inserted panel at index 2
+    assert(moved.active_tab[slot_index(DockSlot::Right)] == 2U);
     const auto right_active = aura::shell::active_panel(moved, DockSlot::Right);
     assert(right_active.has_value());
     assert(*right_active == PanelId::TelemetryOverview);
@@ -209,8 +216,8 @@ void test_full_panel_shuffle_preserves_uniqueness() {
 
     // Default:
     //   Left = { TelemetryOverview }
-    //   Center = { RenderSurface }
-    //   Right = { TopProcesses, DvrTimeline, ProcessPanel }
+    //   Center = { RenderSurface, DvrTimeline }
+    //   Right = { ProcessPanel, TopProcesses }
 
     auto state = aura::shell::build_default_dock_state();
     assert_single_instance_per_panel(state);

--- a/tests/test_shell/native/dock_model_tests.cpp
+++ b/tests/test_shell/native/dock_model_tests.cpp
@@ -58,23 +58,23 @@ void test_active_tab_clamps_after_panel_removal() {
     using aura::shell::PanelId;
     using aura::shell::PanelMoveRequest;
 
-    // Right has {TopProcesses, DvrTimeline, ProcessPanel} -- set active to 2 (ProcessPanel)
+    // Right has {ProcessPanel, TopProcesses} -- set active to 1 (TopProcesses)
     auto state = aura::shell::build_default_dock_state();
-    state = aura::shell::set_active_tab(state, DockSlot::Right, 2U);
+    state = aura::shell::set_active_tab(state, DockSlot::Right, 1U);
 
-    // Move ProcessPanel out -- Right now has 2 panels, active should clamp to 1
+    // Move TopProcesses out -- Right now has 1 panel, active should clamp to 0
     const auto moved = aura::shell::move_panel(
         state,
         PanelMoveRequest{
-            .panel_id = PanelId::ProcessPanel,
+            .panel_id = PanelId::TopProcesses,
             .to_slot = DockSlot::Left,
             .to_index = std::nullopt,
         }
     );
-    assert(moved.active_tab[slot_index(DockSlot::Right)] == 1U);
+    assert(moved.active_tab[slot_index(DockSlot::Right)] == 0U);
     const auto right_panel = aura::shell::active_panel(moved, DockSlot::Right);
     assert(right_panel.has_value());
-    assert(*right_panel == PanelId::DvrTimeline);
+    assert(*right_panel == PanelId::ProcessPanel);
 }
 
 void test_destination_active_tab_tracks_inserted_panel() {
@@ -84,7 +84,7 @@ void test_destination_active_tab_tracks_inserted_panel() {
 
     const auto state = aura::shell::build_default_dock_state();
     // Move TelemetryOverview to Right at index 0
-    // Right was {TopProcesses, DvrTimeline, ProcessPanel} -> becomes {TelemetryOverview, TopProcesses, DvrTimeline, ProcessPanel}
+    // Right was {ProcessPanel, TopProcesses} -> becomes {TelemetryOverview, ProcessPanel, TopProcesses}
     const auto moved = aura::shell::move_panel(
         state,
         PanelMoveRequest{
@@ -153,7 +153,7 @@ void test_all_panels_to_single_slot() {
 
     auto state = aura::shell::build_default_dock_state();
 
-    // Default: Left={TelemetryOverview}, Center={RenderSurface}, Right={TopProcesses, DvrTimeline, ProcessPanel}
+    // Default: Left={TelemetryOverview}, Center={RenderSurface, DvrTimeline}, Right={ProcessPanel, TopProcesses}
     // Move RenderSurface -> Left
     state = aura::shell::move_panel(
         state,
@@ -272,18 +272,18 @@ void test_active_tab_round_trips() {
     using aura::shell::PanelId;
     using aura::shell::PanelMoveRequest;
 
-    // Default: Left={TelemetryOverview[0]}, Center={RenderSurface[0]}, Right={TopProcesses[0], DvrTimeline[1], ProcessPanel[2]}
+    // Default: Left={TelemetryOverview[0]}, Center={RenderSurface[0], DvrTimeline[1]}, Right={ProcessPanel[0], TopProcesses[1]}
     auto state = aura::shell::build_default_dock_state();
 
-    // Set Right active tab to 1 (DvrTimeline)
+    // Set Right active tab to 1 (TopProcesses)
     state = aura::shell::set_active_tab(state, DockSlot::Right, 1U);
     assert(state.active_tab[slot_index(DockSlot::Right)] == 1U);
 
-    // Confirm active_panel reflects DvrTimeline
+    // Confirm active_panel reflects TopProcesses
     {
         const auto panel = aura::shell::active_panel(state, DockSlot::Right);
         assert(panel.has_value());
-        assert(*panel == PanelId::DvrTimeline);
+        assert(*panel == PanelId::TopProcesses);
     }
 
     // Move RenderSurface from Center to Center at explicit index 0 (stays there)
@@ -296,11 +296,11 @@ void test_active_tab_round_trips() {
         }
     );
 
-    // Right active tab should still resolve to DvrTimeline (unchanged by this move)
+    // Right active tab should still resolve to TopProcesses (unchanged by this move)
     {
         const auto panel = aura::shell::active_panel(state, DockSlot::Right);
         assert(panel.has_value());
-        assert(*panel == PanelId::DvrTimeline);
+        assert(*panel == PanelId::TopProcesses);
     }
 
     // Center active_tab was updated to 0 (insertion at 0); RenderSurface should still be active
@@ -316,7 +316,7 @@ void test_active_tab_round_trips() {
     {
         const auto panel = aura::shell::active_panel(state, DockSlot::Right);
         assert(panel.has_value());
-        assert(*panel == PanelId::TopProcesses);
+        assert(*panel == PanelId::ProcessPanel);
     }
 
     // Uniqueness invariant
@@ -336,10 +336,10 @@ void test_panel_ordering_after_moves() {
 
     // Start fresh
     auto state = aura::shell::build_default_dock_state();
-    // Default: Left={TelemetryOverview}, Center={RenderSurface}, Right={TopProcesses, DvrTimeline, ProcessPanel}
+    // Default: Left={TelemetryOverview}, Center={RenderSurface, DvrTimeline}, Right={ProcessPanel, TopProcesses}
 
     // Move TopProcesses from Right to Center at index 0
-    // Center becomes: {TopProcesses, RenderSurface}
+    // Center becomes: {TopProcesses, RenderSurface, DvrTimeline}
     state = aura::shell::move_panel(
         state,
         PanelMoveRequest{
@@ -348,32 +348,19 @@ void test_panel_ordering_after_moves() {
             .to_index = 0U,
         }
     );
-    assert(state.slot_tabs[slot_index(DockSlot::Center)].size() == 2U);
+    assert(state.slot_tabs[slot_index(DockSlot::Center)].size() == 3U);
     assert(state.slot_tabs[slot_index(DockSlot::Center)][0] == PanelId::TopProcesses);
     assert(state.slot_tabs[slot_index(DockSlot::Center)][1] == PanelId::RenderSurface);
+    assert(state.slot_tabs[slot_index(DockSlot::Center)][2] == PanelId::DvrTimeline);
 
     // Move TelemetryOverview from Left to Center at index 1
-    // Center becomes: {TopProcesses, TelemetryOverview, RenderSurface}
+    // Center becomes: {TopProcesses, TelemetryOverview, RenderSurface, DvrTimeline}
     state = aura::shell::move_panel(
         state,
         PanelMoveRequest{
             .panel_id = PanelId::TelemetryOverview,
             .to_slot = DockSlot::Center,
             .to_index = 1U,
-        }
-    );
-    assert(state.slot_tabs[slot_index(DockSlot::Center)].size() == 3U);
-    assert(state.slot_tabs[slot_index(DockSlot::Center)][0] == PanelId::TopProcesses);
-    assert(state.slot_tabs[slot_index(DockSlot::Center)][1] == PanelId::TelemetryOverview);
-    assert(state.slot_tabs[slot_index(DockSlot::Center)][2] == PanelId::RenderSurface);
-
-    // Move DvrTimeline from Right to Center at end
-    state = aura::shell::move_panel(
-        state,
-        PanelMoveRequest{
-            .panel_id = PanelId::DvrTimeline,
-            .to_slot = DockSlot::Center,
-            .to_index = std::nullopt,
         }
     );
     assert(state.slot_tabs[slot_index(DockSlot::Center)].size() == 4U);


### PR DESCRIPTION
## Summary
- **Health gauge flickering** — cached analytics results persist across non-refresh ticks so the gauge stays visible
- **Resizable panels** — replaced fixed QHBoxLayout with QSplitter (1:3:1 initial ratio, draggable handles)
- **Default layout** — moved DvrTimeline to Center panel alongside RenderSurface for readable charts
- **Native window resize** — removed Qt eventFilter resize handling; rely entirely on WM_NCHITTEST for proper edge resize behavior (matches Task Manager, VS Code, Chrome)
- **Tab reordering** — enabled QTabBar drag reordering within dock slots
- **Legend toggle** — clicking timeline legend pills shows/hides individual series (CPU, MEM, GPU)
- **QSplitter styling** — subtle handle with accent color on hover/press

## Test plan
- [x] Shell tests pass (27 tests, 5 suites)
- [x] Platform + telemetry tests pass
- [x] GUI builds successfully
- [ ] Manual: health gauge stays visible continuously
- [ ] Manual: drag splitter handles to resize panels
- [ ] Manual: resize window from edges — cursor appears at window border, not inside
- [ ] Manual: click legend pills to toggle series visibility
- [ ] Manual: drag tabs to reorder within a slot

🤖 Generated with [Claude Code](https://claude.com/claude-code)