### PR TITLE
fix(shell): cross-zone tab drag, gauge tooltips, animation polish

### DIFF
--- a/src/shell/native/include/aura_shell/aura_shell_window.hpp
+++ b/src/shell/native/include/aura_shell/aura_shell_window.hpp
@@ -1,9 +1,11 @@
 #pragma once
 
 #include <QApplication>
+#include <QDrag>
 #include <QFrame>
 #include <QLabel>
 #include <QMainWindow>
+#include <QMimeData>
 #include <QMouseEvent>
 #include <QPushButton>
 #include <QQuickWidget>
@@ -28,6 +30,27 @@
 
 namespace aura::shell {
 
+// Forward declaration
+class AuraShellWindow;
+
+// ── DragTabBar: tab bar that supports cross-zone drag-and-drop ──
+// Starts a QDrag with MIME "application/x-aura-panel-id" when a tab is
+// dragged beyond a small threshold. Destination slot frames accept the
+// drop and call move_panel_to_slot().
+class DragTabBar final : public QTabBar {
+    Q_OBJECT
+public:
+    explicit DragTabBar(DockSlot slot, AuraShellWindow* window, QWidget* parent = nullptr);
+protected:
+    void mousePressEvent(QMouseEvent* event) override;
+    void mouseMoveEvent(QMouseEvent* event) override;
+private:
+    DockSlot slot_;
+    AuraShellWindow* window_;
+    QPoint drag_start_;
+    int drag_tab_index_{-1};
+};
+
 struct SlotWidgets {
     QFrame* frame;
     QTabBar* tab_bar;
@@ -35,6 +58,8 @@ struct SlotWidgets {
 };
 
 class AuraShellWindow final : public QMainWindow {
+    Q_OBJECT
+    friend class DragTabBar;
 public:
     explicit AuraShellWindow(const LaunchConfig& config, QWidget* parent = nullptr);
 

--- a/src/shell/native/qml/CockpitScene.qml
+++ b/src/shell/native/qml/CockpitScene.qml
@@ -1204,6 +1204,25 @@ Rectangle {
                 width: root.effectiveGaugeSize
                 height: root.effectiveGaugeSize
 
+                MouseArea {
+                    anchors.fill: parent
+                    hoverEnabled: true
+                    acceptedButtons: Qt.NoButton
+                    property bool hovered: false
+                    onEntered: { hovered = true; hoverTimer.restart() }
+                    onExited: { hovered = false; hoverTimer.stop(); root.hideTooltip() }
+                    Timer {
+                        id: hoverTimer
+                        interval: 400
+                        onTriggered: {
+                            var trend = root.cpuTrend === 1 ? "Rising" : root.cpuTrend === 2 ? "Falling" : "Stable"
+                            root.showTooltip(cpuGaugeItem, "CPU",
+                                "Processor utilization across all cores",
+                                root.smoothCpu.toFixed(1) + "% \u2022 " + root.coreCount + " threads \u2022 " + trend)
+                        }
+                    }
+                }
+
                 Canvas {
                     id: cpuGlowCanvas
                     anchors.centerIn: parent
@@ -1343,6 +1362,25 @@ Rectangle {
                 width: root.effectiveGaugeSize
                 height: root.effectiveGaugeSize
 
+                MouseArea {
+                    anchors.fill: parent
+                    hoverEnabled: true
+                    acceptedButtons: Qt.NoButton
+                    property bool hovered: false
+                    onEntered: { hovered = true; memHoverTimer.restart() }
+                    onExited: { hovered = false; memHoverTimer.stop(); root.hideTooltip() }
+                    Timer {
+                        id: memHoverTimer
+                        interval: 400
+                        onTriggered: {
+                            var trend = root.memoryTrend === 1 ? "Rising" : root.memoryTrend === 2 ? "Falling" : "Stable"
+                            root.showTooltip(memGaugeItem, "MEMORY",
+                                "Physical memory utilization",
+                                root.smoothMem.toFixed(1) + "% \u2022 " + trend)
+                        }
+                    }
+                }
+
                 Canvas {
                     id: memGlowCanvas
                     anchors.centerIn: parent
@@ -1448,6 +1486,26 @@ Rectangle {
                 height: root.effectiveGaugeSize
                 visible: root.gpuAvailable
 
+                MouseArea {
+                    anchors.fill: parent
+                    hoverEnabled: true
+                    acceptedButtons: Qt.NoButton
+                    property bool hovered: false
+                    onEntered: { hovered = true; gpuHoverTimer.restart() }
+                    onExited: { hovered = false; gpuHoverTimer.stop(); root.hideTooltip() }
+                    Timer {
+                        id: gpuHoverTimer
+                        interval: 400
+                        onTriggered: {
+                            var vramUsed = (root.vramUsedBytes / 1073741824).toFixed(1)
+                            var vramTotal = (root.vramTotalBytes / 1073741824).toFixed(0)
+                            root.showTooltip(gpuGaugeItem, "GPU",
+                                "Graphics processor utilization",
+                                root.smoothGpu.toFixed(1) + "% \u2022 " + vramUsed + "/" + vramTotal + " GB VRAM")
+                        }
+                    }
+                }
+
                 Canvas {
                     id: gpuGlowCanvas
                     anchors.centerIn: parent
@@ -1511,6 +1569,28 @@ Rectangle {
                 width: root.effectiveGaugeSize
                 height: root.effectiveGaugeSize
                 visible: root.healthAvailable
+
+                MouseArea {
+                    anchors.fill: parent
+                    hoverEnabled: true
+                    acceptedButtons: Qt.NoButton
+                    property bool hovered: false
+                    onEntered: { hovered = true; healthHoverTimer.restart() }
+                    onExited: { hovered = false; healthHoverTimer.stop(); root.hideTooltip() }
+                    Timer {
+                        id: healthHoverTimer
+                        interval: 400
+                        onTriggered: {
+                            root.showTooltip(healthGaugeItem, "HEALTH",
+                                "Composite system health score (0\u2013100)",
+                                "Overall " + root.smoothHealth.toFixed(0) +
+                                " \u2022 CPU " + root.healthCpu.toFixed(0) +
+                                " \u2022 MEM " + root.healthMemory.toFixed(0) +
+                                " \u2022 DISK " + root.healthDisk.toFixed(0) +
+                                " \u2022 NET " + root.healthNetwork.toFixed(0))
+                        }
+                    }
+                }
 
                 Canvas {
                     id: healthGlowCanvas
@@ -2730,5 +2810,76 @@ Rectangle {
         Behavior on border.color {
             ColorAnimation { duration: 400; easing.type: Easing.OutCubic }
         }
+    }
+
+    // =========================================================================
+    // SHARED GAUGE TOOLTIP — positioned near hovered gauge
+    // =========================================================================
+    Rectangle {
+        id: gaugeTooltip
+        visible: false
+        z: 100
+        width: tooltipCol.implicitWidth + 20
+        height: tooltipCol.implicitHeight + 14
+        radius: 6
+        color: root.pinkMode ? Qt.rgba(0.12, 0.04, 0.09, 0.92) : Qt.rgba(0.05, 0.08, 0.14, 0.92)
+        border.width: 1
+        border.color: root.clrAccent
+
+        property string title: ""
+        property string description: ""
+        property string value: ""
+
+        Behavior on opacity { NumberAnimation { duration: 150; easing.type: Easing.OutCubic } }
+
+        Column {
+            id: tooltipCol
+            anchors.centerIn: parent
+            spacing: 3
+
+            Text {
+                text: gaugeTooltip.title
+                color: root.clrTextPrimary
+                font.pixelSize: Math.max(9, root.fontGaugeLabel)
+                font.weight: Font.Bold
+                font.letterSpacing: 1
+                font.family: "Segoe UI"
+            }
+            Text {
+                text: gaugeTooltip.description
+                color: root.clrTextMuted
+                font.pixelSize: Math.max(8, root.fontGaugeLabel - 1)
+                font.family: "Segoe UI"
+                visible: text.length > 0
+            }
+            Text {
+                text: gaugeTooltip.value
+                color: root.clrTextSecondary
+                font.pixelSize: Math.max(8, root.fontGaugeLabel - 1)
+                font.weight: Font.DemiBold
+                font.family: "Segoe UI"
+                visible: text.length > 0
+            }
+        }
+    }
+
+    // Tooltip show/hide helpers
+    function showTooltip(item, title, description, value) {
+        var pos = item.mapToItem(root, item.width / 2, item.height + 6)
+        gaugeTooltip.title = title
+        gaugeTooltip.description = description
+        gaugeTooltip.value = value
+        // Clamp to root bounds
+        var tx = Math.max(4, Math.min(pos.x - gaugeTooltip.width / 2, root.width - gaugeTooltip.width - 4))
+        var ty = pos.y
+        if (ty + gaugeTooltip.height > root.height - 4)
+            ty = item.mapToItem(root, 0, -gaugeTooltip.height - 6).y
+        gaugeTooltip.x = tx
+        gaugeTooltip.y = ty
+        gaugeTooltip.visible = true
+    }
+
+    function hideTooltip() {
+        gaugeTooltip.visible = false
     }
 }

--- a/src/shell/native/qml/TimelineScene.qml
+++ b/src/shell/native/qml/TimelineScene.qml
@@ -169,6 +169,9 @@ Rectangle {
                 border.color: Qt.rgba(modelData.sc[0], modelData.sc[1], modelData.sc[2],
                     seriesVisible ? modelData.sc[3] * 0.7 : 0.20)
                 opacity: seriesVisible ? 1.0 : 0.45
+                Behavior on opacity { NumberAnimation { duration: 200; easing.type: Easing.OutCubic } }
+                Behavior on color { ColorAnimation { duration: 200; easing.type: Easing.OutCubic } }
+                Behavior on border.color { ColorAnimation { duration: 200; easing.type: Easing.OutCubic } }
 
                 Text {
                     id: pillText
@@ -386,6 +389,7 @@ Rectangle {
         anchors.rightMargin: marginH
         anchors.topMargin: marginV * 2.2
         anchors.bottomMargin: marginV * 0.3
+        antialiasing: true
 
         onPaint: {
             var ctx = getContext("2d")

--- a/src/shell/native/src/aura_shell_window.cpp
+++ b/src/shell/native/src/aura_shell_window.cpp
@@ -30,11 +30,15 @@
 #include "aura_shell/timeline_bridge.hpp"
 
 #include <QApplication>
+#include <QDrag>
+#include <QDragEnterEvent>
+#include <QDropEvent>
 #include <QEvent>
 #include <QFont>
 #include <QFrame>
 #include <QHBoxLayout>
 #include <QLabel>
+#include <QMimeData>
 #include <QMouseEvent>
 #include <QResizeEvent>
 #include <QObject>
@@ -343,6 +347,31 @@ bool AuraShellWindow::nativeEvent(const QByteArray& /*eventType*/, void* message
 #endif
 
 bool AuraShellWindow::eventFilter(QObject* watched, QEvent* event) {
+    // ── Cross-zone drag-and-drop on slot frames ──────────────────────────
+    if (event->type() == QEvent::DragEnter) {
+        auto* de = static_cast<QDragEnterEvent*>(event);
+        if (de->mimeData()->hasFormat(QString::fromLatin1(k_panel_mime))) {
+            de->acceptProposedAction();
+            return true;
+        }
+    }
+    if (event->type() == QEvent::Drop) {
+        auto* de = static_cast<QDropEvent*>(event);
+        if (de->mimeData()->hasFormat(QString::fromLatin1(k_panel_mime))) {
+            const int panel_int = de->mimeData()->data(QString::fromLatin1(k_panel_mime)).toInt();
+            const auto panel_id = static_cast<PanelId>(panel_int);
+
+            // Find which slot frame received the drop
+            for (const auto target_slot : all_dock_slots()) {
+                if (slot_widgets_[slot_index(target_slot)].frame == watched) {
+                    move_panel_to_slot(panel_id, target_slot);
+                    de->acceptProposedAction();
+                    return true;
+                }
+            }
+        }
+    }
+
     // Titlebar drag + double-click (resize is handled natively via WM_NCHITTEST)
     if (watched == titlebar_) {
         if (event->type() == QEvent::MouseButtonPress) {
@@ -517,8 +546,8 @@ SlotWidgets AuraShellWindow::build_slot(const DockSlot slot, QWidget* parent) {
     zone_label->setObjectName("slotZoneLabel");
     zone_label->setContentsMargins(12, 0, 0, 2);
 
-    // Tab bar sits flush below the zone label — movable for reordering
-    auto* tab_bar = new QTabBar(frame);
+    // Tab bar with cross-zone drag-and-drop support
+    auto* tab_bar = new DragTabBar(slot, this, frame);
     tab_bar->setDocumentMode(true);
     tab_bar->setExpanding(false);
     tab_bar->setMovable(true);
@@ -534,7 +563,53 @@ SlotWidgets AuraShellWindow::build_slot(const DockSlot slot, QWidget* parent) {
     layout->addWidget(tab_bar);
     layout->addWidget(stack, 1);
 
+    // Enable drop on frame for cross-zone panel moves
+    frame->setAcceptDrops(true);
+    frame->installEventFilter(this);
+
     return {frame, tab_bar, stack};
+}
+
+// ── DragTabBar implementation ────────────────────────────────────────────────
+
+static constexpr const char* k_panel_mime = "application/x-aura-panel-id";
+
+DragTabBar::DragTabBar(const DockSlot slot, AuraShellWindow* window, QWidget* parent)
+    : QTabBar(parent), slot_(slot), window_(window) {}
+
+void DragTabBar::mousePressEvent(QMouseEvent* event) {
+    if (event->button() == Qt::LeftButton) {
+        drag_start_ = event->pos();
+        drag_tab_index_ = tabAt(event->pos());
+    }
+    QTabBar::mousePressEvent(event);
+}
+
+void DragTabBar::mouseMoveEvent(QMouseEvent* event) {
+    if (drag_tab_index_ >= 0
+        && (event->buttons() & Qt::LeftButton)
+        && (event->pos() - drag_start_).manhattanLength() >= QApplication::startDragDistance() * 2) {
+
+        // Resolve which PanelId is at this tab index
+        const auto slot_idx = slot_index(slot_);
+        const auto& tabs = window_->dock_state_.slot_tabs[slot_idx];
+        if (drag_tab_index_ >= static_cast<int>(tabs.size())) {
+            drag_tab_index_ = -1;
+            return;
+        }
+        const auto panel_id = tabs[static_cast<std::size_t>(drag_tab_index_)];
+
+        auto* mime = new QMimeData();
+        mime->setData(QString::fromLatin1(k_panel_mime),
+                      QByteArray::number(static_cast<int>(panel_id)));
+
+        auto* drag = new QDrag(this);
+        drag->setMimeData(mime);
+        drag->exec(Qt::MoveAction);
+        drag_tab_index_ = -1;
+        return;
+    }
+    QTabBar::mouseMoveEvent(event);
 }
 
 }  // namespace aura::shell


### PR DESCRIPTION
## Summary
- **Cross-zone tab drag** — New `DragTabBar` subclass starts `QDrag` with MIME `application/x-aura-panel-id` when dragged past threshold. Slot frames accept drops and route to `move_panel_to_slot()`. Panels can now be dragged between LEFT/CENTER/RIGHT zones.
- **Gauge tooltips** — Hover >400ms on CPU, Memory, GPU, or Health gauge shows a semi-transparent tooltip with metric name, description, current value, and context (trend, core count, VRAM, sub-scores). Tooltip auto-positions below gauge and clamps to root bounds.
- **Animation polish** — Legend pill opacity/color transitions use 200ms `Easing.OutCubic` Behaviors. Timeline chart canvas has `antialiasing: true`. Smooth Y-axis range transitions from PR 1 carry through.

**Base:** `fix/shell-window-and-charts` (PR #32) — merge that first, then this.

## Test plan
- [ ] `.\aura.cmd build gui` compiles
- [ ] `.\aura.cmd test shell` — all tests pass
- [ ] Drag a tab from LEFT zone to CENTER zone — panel moves to center slot
- [ ] Drag a tab from CENTER zone to RIGHT zone — panel moves to right slot
- [ ] Hover over CPU gauge for 400ms+ — tooltip shows "CPU", description, current %, trend
- [ ] Hover over GPU gauge — tooltip shows VRAM usage
- [ ] Hover over Health gauge — tooltip shows sub-scores
- [ ] Move mouse off gauge — tooltip hides
- [ ] Toggle legend pill — opacity transition is smooth (not instant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)