### PR TITLE
fix(shell): 6 frontend visual bugs — health gauge, alert breath, theme sync, render status, drag border, sparkline

### DIFF
--- a/src/render/native/src/widgets_models.cpp
+++ b/src/render/native/src/widgets_models.cpp
@@ -160,10 +160,12 @@ std::vector<double> SparkLineModel::normalized_buffer() const {
     out.reserve(buffer_.size());
 
     if (range < 1e-9) {
-        // All values are effectively equal — map them all to 0.5 so the
-        // spark line still renders at mid-height rather than collapsing.
+        // All values are effectively equal. Map to the actual percent position
+        // in [0, 1] so an idle CPU at 4% renders near-bottom, not at midpoint.
+        // Floor at 0.05 so the line is always visible (not collapsed to zero).
+        const double actual_pos = std::clamp(buffer_.front() / 100.0, 0.05, 0.95);
         for (std::size_t i = 0; i < buffer_.size(); ++i) {
-            out.push_back(0.5);
+            out.push_back(actual_pos);
         }
     } else {
         for (const double v : buffer_) {

--- a/src/shell/native/qml/CockpitScene.qml
+++ b/src/shell/native/qml/CockpitScene.qml
@@ -85,11 +85,34 @@ Rectangle {
 
     // Alert glow breathing intensity
     property real alertBreath: 0.0
-    SequentialAnimation on alertBreath {
-        running: root.cpuAlertActive
+
+    SequentialAnimation {
+        id: alertBreathLoop
         loops: Animation.Infinite
-        NumberAnimation { to: 1.0; duration: 600; easing.type: Easing.InOutSine }
-        NumberAnimation { to: 0.3; duration: 600; easing.type: Easing.InOutSine }
+        NumberAnimation { target: root; property: "alertBreath"; to: 1.0; duration: 600; easing.type: Easing.InOutSine }
+        NumberAnimation { target: root; property: "alertBreath"; to: 0.3; duration: 600; easing.type: Easing.InOutSine }
+    }
+
+    NumberAnimation {
+        id: alertBreathFadeOut
+        target: root
+        property: "alertBreath"
+        to: 0.0
+        duration: 400
+        easing.type: Easing.OutCubic
+    }
+
+    Connections {
+        target: root
+        function onCpuAlertActiveChanged() {
+            if (root.cpuAlertActive) {
+                alertBreathFadeOut.stop()
+                alertBreathLoop.start()
+            } else {
+                alertBreathLoop.stop()
+                alertBreathFadeOut.start()
+            }
+        }
     }
 
     // Smoothed health for gauge animation
@@ -274,10 +297,11 @@ Rectangle {
             g = 0.620 + (0.773 - 0.620) * t2
             b = 0.043 + (0.369 - 0.043) * t2
         } else {
+            // 80 → 100: #22c55e → #00ff87 (saturated mint, peak health — visually distinct)
             var t3 = (score - 80) / 20.0
-            r = 0.133 + (0.133 - 0.133) * t3
-            g = 0.773 + (0.773 - 0.773) * t3
-            b = 0.369 + (0.369 - 0.369) * t3
+            r = 0.133 + (0.000 - 0.133) * t3
+            g = 0.773 + (1.000 - 0.773) * t3
+            b = 0.369 + (0.529 - 0.369) * t3
         }
         return Qt.rgba(
             Math.max(0, Math.min(1, r)),

--- a/src/shell/native/src/aura_shell_window_panels.cpp
+++ b/src/shell/native/src/aura_shell_window_panels.cpp
@@ -219,6 +219,12 @@ void AuraShellWindow::build_panel_pages() {
         timeline_quick_->setSource(
             QUrl::fromLocalFile(QStringLiteral(AURA_SHELL_TIMELINE_QML_PATH)));
         timeline_quick_->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+        // Re-arm theme dirty flag when QML scene finishes loading — handles the
+        // startup race where apply_theme() fires before rootObject() is available.
+        connect(timeline_quick_, &QQuickWidget::statusChanged,
+                this, [this](QQuickWidget::Status status) {
+            if (status == QQuickWidget::Ready) { theme_dirty_ = true; }
+        });
 
         timeline_status_ = new QLabel("Awaiting timeline samples...", parent_page);
         timeline_status_->setObjectName("timelineStatus");
@@ -239,6 +245,10 @@ void AuraShellWindow::build_panel_pages() {
         quick_->setResizeMode(QQuickWidget::SizeRootObjectToView);
         quick_->setSource(QUrl::fromLocalFile(QStringLiteral(AURA_SHELL_QML_PATH)));
         quick_->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+        connect(quick_, &QQuickWidget::statusChanged,
+                this, [this](QQuickWidget::Status status) {
+            if (status == QQuickWidget::Ready) { theme_dirty_ = true; }
+        });
 
         render_status_ = new QLabel("Cockpit scene online", parent_page);
         render_status_->setObjectName("renderStatus");
@@ -265,6 +275,10 @@ void AuraShellWindow::build_panel_pages() {
         process_quick_->setSource(
             QUrl::fromLocalFile(QStringLiteral(AURA_SHELL_PROCESS_QML_PATH)));
         process_quick_->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+        connect(process_quick_, &QQuickWidget::statusChanged,
+                this, [this](QQuickWidget::Status status) {
+            if (status == QQuickWidget::Ready) { theme_dirty_ = true; }
+        });
 
         process_layout->addWidget(process_quick_, 1);
     }

--- a/src/shell/native/src/aura_shell_window_refresh.cpp
+++ b/src/shell/native/src/aura_shell_window_refresh.cpp
@@ -57,7 +57,19 @@ void AuraShellWindow::refresh_cockpit() {
         thermal_value_->setText(QStringLiteral("\u2014"));
     }
     process_status_->setText(QString::fromStdString(state.status_line));
-    render_status_->setText(QString::fromStdString(state.status_line));
+    if (!state.render_available) {
+        const QString err = state.style_token_error.empty()
+            ? QStringLiteral("unknown error")
+            : QString::fromStdString(state.style_token_error);
+        render_status_->setText(QStringLiteral("Render degraded \u2014 ") + err);
+    } else {
+        render_status_->setText(
+            QString::asprintf("Render ok | fps=%d | sev=%d | tokens=%s",
+                state.fps_target,
+                state.severity_level,
+                state.style_tokens_available ? "ok" : "missing")
+        );
+    }
     timeline_status_->setText(QString::fromStdString(state.timeline_line));
 
     for (std::size_t i = 0; i < process_labels_.size(); ++i) {
@@ -302,7 +314,15 @@ void AuraShellWindow::refresh_cockpit() {
     }
 
     if (theme_dirty_) {
-        theme_dirty_ = false;
+        // Only clear once all three QML scenes have successfully received the update.
+        // If any root is still nullptr (QML loading), the flag stays dirty and is
+        // retried on the next tick — preventing silent theme loss at startup.
+        const bool cockpit_ready  = (quick_ != nullptr && quick_->rootObject() != nullptr);
+        const bool timeline_ready = (timeline_quick_ != nullptr && timeline_quick_->rootObject() != nullptr);
+        const bool process_ready  = (process_quick_ != nullptr && process_quick_->rootObject() != nullptr);
+        if (cockpit_ready && timeline_ready && process_ready) {
+            theme_dirty_ = false;
+        }
     }
 
     if (update_timer_ != nullptr) {

--- a/src/shell/native/src/stylesheet_builder.cpp
+++ b/src/shell/native/src/stylesheet_builder.cpp
@@ -105,15 +105,17 @@ QString build_app_stylesheet(const UiThemeMode mode, const SizeMetrics& m) {
         "    border-color: ${ACCENT};"
         "}"
         // --- Dock slot frames ---
+        // Fixed 2px border in both states — prevents 1px layout shift during drag hover.
+        // Radius stays constant so content doesn't jump when auraDragOver toggles.
         "QFrame#slot {"
         "    background: ${BG_PANEL};"
-        "    border: 1px solid ${BORDER_SUBTLE};"
+        "    border: 2px solid ${BORDER_SUBTLE};"
         "    border-radius: 10px;"
         "    padding: 0px;"
         "}"
         "QFrame#slot[auraDragOver=\"true\"] {"
         "    border: 2px solid ${ACCENT};"
-        "    border-radius: 12px;"
+        "    border-radius: 10px;"
         "}"
         // --- Slot zone label ---
         "QLabel#slotZoneLabel {"


### PR DESCRIPTION
## Summary

Fixes 6 confirmed frontend/visual bugs found during comprehensive render audit. All changes are isolated, low-risk, and build clean.

- **Bug #1 — `healthGaugeColor` dead formula (CRITICAL):** The 80–100% health range computed `start + (start - start) * t = start` — literally no color change. Health at 85 looked identical to 100. Fixed: transitions `#22c55e → #00ff87` (neon mint peak) so excellent health is visually distinct.

- **Bug #2 — `alertBreath` frozen on alert clear (HIGH):** `SequentialAnimation on alertBreath { running: cpuAlertActive }` stops mid-animation when the alert clears, leaving the glow permanently lit at whatever opacity it was at. Fixed: separate `breathAnimation` (looping while active) + `alertBreathFadeOut` (smooth 400ms fade to 0 on clear), driven by `onCpuAlertActiveChanged`.

- **Bug #3 — `theme_dirty_` cleared even when QML sync skipped (HIGH):** Flag was unconditionally cleared at end of `refresh_cockpit()` even if any QML `rootObject()` was still null (loading). Startup theme changes were silently lost. Fixed: only clear when all three scenes confirm sync; added `statusChanged → theme_dirty_ = true` on each `QQuickWidget` so late-loading scenes get the theme pushed when they become ready.

- **Bug #7 — `render_status_` and `process_status_` showed identical text (MEDIUM):** Both labels received `state.status_line`. `render_status_` now shows a render-specific line: `"Render ok | fps=60 | sev=0 | tokens=ok"` or `"Render degraded — <error>"`.

- **Bug #9 — Slot drag highlight caused 1px content shift (MEDIUM):** `QFrame#slot` border changed `1px → 2px` + `border-radius: 10px → 12px` on drag hover, shifting content inward by 1px. Fixed: always use `2px` border and constant `border-radius: 10px` — only the color changes on drag.

- **Bug #10 — SparkLine flat data mapped to 0.5 midpoint (MEDIUM):** When all buffer values were equal (e.g. CPU steady at 4%), `normalized_buffer()` returned 0.5 for every sample, showing the sparkline at 50% height regardless of actual load. Fixed: maps to actual `value / 100.0` position (floored at 0.05 for visibility).

## Test plan

- [ ] Launch Aura and toggle theme (pink/blue) — both modes should apply immediately, including after startup
- [ ] Switch to pink mode → watch health gauge: scores 80–100 should brighten towards mint, not stay flat green
- [ ] Trigger a CPU alert (if threshold is reachable) → let it clear → verify glow fades smoothly to zero
- [ ] Check the Render Surface panel status bar — should show fps/severity info, not duplicate telemetry text
- [ ] Drag a panel tab across slots — target slot highlight should not cause content to shift by 1px
- [ ] Let CPU sit idle for 60s → sparkline should render near the bottom, not at midpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)