### PR TITLE
fix(shell): 10 frontend bugs — alpha curves, pulse sync, gauge color, RAM, shimmer, aurora, Y-axis, drag timer

### DIFF
--- a/src/render/native/src/qt_hooks.cpp
+++ b/src/render/native/src/qt_hooks.cpp
@@ -15,7 +15,8 @@ namespace {
 
 constexpr int kDefaultTargetFps = 60;
 constexpr int kDefaultMaxCatchupFrames = 4;
-constexpr double kDefaultPulseHz = 0.5;
+// Bug #16: unified pulse rate — matches render_bridge.cpp (0.35 Hz ≈ 2.9s cycle).
+constexpr double kDefaultPulseHz = 0.35;
 
 struct TrendState {
     bool initialized{false};
@@ -23,7 +24,10 @@ struct TrendState {
     double previous_memory_percent{0.0};
 };
 
-thread_local TrendState g_trend_state{};
+// Bug #12: was thread_local — each thread got independent slope state, breaking
+// cross-thread trend detection.  A single module-static is correct: there is
+// one logical telemetry sequence regardless of which thread calls this function.
+TrendState g_trend_state{};
 
 FrameDiscipline resolve_discipline(const QtRenderFrameInput& input) {
     return FrameDiscipline{
@@ -46,14 +50,21 @@ double resolve_elapsed(double value) {
     return value;
 }
 
+// Bug #11: cpu and memory alpha were identical — both used linear [0.20, 0.95].
+// CPU spikes are transient and alarming: sqrt curve makes low-mid load visible
+// immediately (10% CPU → alpha 0.37 vs 0.175 with old linear).
+// Memory fills gradually and persists: higher floor (always somewhat "in use"),
+// gentler linear slope so it doesn't scream when 8 tabs of Chrome are open.
 double compute_cpu_alpha(double cpu_percent) {
     const double ratio = sanitize_percent(cpu_percent) / 100.0;
-    return clamp_unit(0.20 + (ratio * 0.75));
+    // sqrt curve: idle (0%) = 0.10, full load (100%) = 0.95
+    return clamp_unit(0.10 + (std::sqrt(ratio) * 0.85));
 }
 
 double compute_memory_alpha(double memory_percent) {
     const double ratio = sanitize_percent(memory_percent) / 100.0;
-    return clamp_unit(0.20 + (ratio * 0.75));
+    // linear: idle (0%) = 0.30, full load (100%) = 0.92
+    return clamp_unit(0.30 + (ratio * 0.62));
 }
 
 double resolve_elapsed_positive(double value) {

--- a/src/render/native/src/theme.cpp
+++ b/src/render/native/src/theme.cpp
@@ -144,25 +144,22 @@ RgbColor interpolate_gauge_color(double percent) {
     static const RgbColor kAmber = {0xf5, 0x9e, 0x0b};  // #f59e0b
     static const RgbColor kRed   = {0xef, 0x44, 0x44};  // #ef4444
 
-    // Segment boundaries
-    // [0, 40)   : flat blue
-    // [40, 70)  : blue -> cyan
-    // [70, 85)  : cyan -> amber
-    // [85, 100] : amber -> red
+    // Bug #14: old segments had a flat [0,40] blue zone — QML used a continuous
+    // gradient from 0%.  Synced to match QML CockpitScene.qml segmentation:
+    //   [0,  50) : blue  → cyan   (continuous from idle)
+    //   [50, 80) : cyan  → amber
+    //   [80, 100]: amber → red
 
-    if (percent <= 40.0) {
-        return kBlue;
-    }
-    if (percent <= 70.0) {
-        const double t = (percent - 40.0) / 30.0;  // [0,1] over [40,70]
+    if (percent <= 50.0) {
+        const double t = percent / 50.0;              // [0,1] over [0,50]
         return blend_rgb(kBlue, kCyan, t);
     }
-    if (percent <= 85.0) {
-        const double t = (percent - 70.0) / 15.0;  // [0,1] over [70,85]
+    if (percent <= 80.0) {
+        const double t = (percent - 50.0) / 30.0;    // [0,1] over [50,80]
         return blend_rgb(kCyan, kAmber, t);
     }
-    // (85, 100]
-    const double t = (percent - 85.0) / 15.0;  // [0,1] over [85,100]
+    // (80, 100]
+    const double t = (percent - 80.0) / 20.0;        // [0,1] over [80,100]
     return blend_rgb(kAmber, kRed, t);
 }
 

--- a/src/shell/native/include/aura_shell/aura_shell_window.hpp
+++ b/src/shell/native/include/aura_shell/aura_shell_window.hpp
@@ -145,6 +145,9 @@ private:
     std::array<QLabel*, 5> panel_title_labels_{};
     bool dragging_{false};
     QPoint drag_origin_{};
+    // Bug #4: cached at first refresh via GlobalMemoryStatusEx — total RAM is
+    // a static hardware fact, not worth querying every tick.
+    std::uint64_t total_physical_memory_bytes_{0};
 #ifdef _WIN32
     bool show_style_applied_{false};
 #endif

--- a/src/shell/native/qml/CockpitScene.qml
+++ b/src/shell/native/qml/CockpitScene.qml
@@ -43,6 +43,9 @@ Rectangle {
     property string statusText: "Waiting for telemetry..."
     property string themeMode: "dark_blue"
     property bool pinkMode: themeMode === "pink_cute"
+    // Bug #6: set by C++ via refresh_cockpit → false when another tab is active,
+    // which pauses aurora/shimmer timers to avoid wasted GPU/CPU work.
+    property bool panelVisible: true
     property bool hasCpuSample: false
     property bool hasMemSample: false
 
@@ -208,11 +211,24 @@ Rectangle {
     }
 
     // Shimmer phase for holographic gauge arcs (pink mode)
+    // Bug #5: was NumberAnimation running at 60fps, triggering onShimmerPhaseChanged
+    // on every frame and causing 60 full Canvas 2D redraws/s on all gauge arcs.
+    // Replaced with a 30fps Timer that manually advances the phase; the per-canvas
+    // onShimmerPhaseChanged connections already call requestPaint() so no change
+    // needed there.  0.011 per tick @ 30fps ≈ 3s full sweep (original 3000ms).
     property real shimmerPhase: 0
-    NumberAnimation on shimmerPhase {
-        running: root.pinkMode && root.motionScale >= 0.05
-        from: 0; to: 1; duration: 3000
-        loops: Animation.Infinite
+
+    Timer {
+        id: shimmerTimer
+        running: root.pinkMode && root.motionScale >= 0.05 && root.panelVisible
+        interval: 33   // ~30 fps
+        repeat: true
+        onTriggered: {
+            root.shimmerPhase = (root.shimmerPhase + 0.011) % 1.0
+        }
+        onRunningChanged: {
+            if (!running) root.shimmerPhase = 0
+        }
     }
 
     // ── Derived accent color helpers ─────────────────────────────────────────
@@ -603,14 +619,17 @@ Rectangle {
         z: 0
 
         property real phase: 0
+        // Bug #6: add panelVisible guard — aurora timer and animation
+        // were firing even when a different tab was selected in the dock,
+        // wasting CPU/GPU on a canvas that wasn't being rendered.
         NumberAnimation on phase {
-            running: root.pinkMode && root.motionScale >= 0.05
+            running: root.pinkMode && root.motionScale >= 0.05 && root.panelVisible
             from: 0; to: Math.PI * 2; duration: 20000
             loops: Animation.Infinite
         }
 
         Timer {
-            running: root.pinkMode && root.motionScale >= 0.05
+            running: root.pinkMode && root.motionScale >= 0.05 && root.panelVisible
             interval: 80
             repeat: true
             onTriggered: auroraCanvas.requestPaint()

--- a/src/shell/native/qml/TimelineScene.qml
+++ b/src/shell/native/qml/TimelineScene.qml
@@ -51,12 +51,33 @@ Rectangle {
     readonly property bool hasData: timelinePoints.length >= 2
 
     // ── Dynamic Y-axis range (auto-scaled per visible series) ────────────
+    // Bug #8: was writing raw computed values directly to chartYMin/chartYMax
+    // inside onPaint, causing 300ms animations to restart every 1s tick and
+    // producing a continuous jitter instead of settling on a stable range.
+    // Fix: separate raw targets from animated values; apply 5pp hysteresis so
+    // minor load fluctuations never trigger the animation at all; slow the
+    // easing to 800ms with OutExpo so genuine range changes settle smoothly.
     property real chartYMin: 0
     property real chartYMax: 100
+    property real chartYMinTarget: 0
+    property real chartYMaxTarget: 100
     property var yAxisTicks: [0, 25, 50, 75, 100]
 
-    Behavior on chartYMin { NumberAnimation { duration: 300; easing.type: Easing.OutCubic } }
-    Behavior on chartYMax { NumberAnimation { duration: 300; easing.type: Easing.OutCubic } }
+    Behavior on chartYMin { NumberAnimation { duration: 800; easing.type: Easing.OutExpo } }
+    Behavior on chartYMax { NumberAnimation { duration: 800; easing.type: Easing.OutExpo } }
+
+    // Update Y range with hysteresis: only animate if target shifts > 5 pp.
+    function updateYRange(newMin, newMax) {
+        var kHysteresis = 5.0
+        if (Math.abs(newMin - root.chartYMinTarget) > kHysteresis) {
+            root.chartYMinTarget = newMin
+            root.chartYMin = newMin
+        }
+        if (Math.abs(newMax - root.chartYMaxTarget) > kHysteresis) {
+            root.chartYMaxTarget = newMax
+            root.chartYMax = newMax
+        }
+    }
 
     // ── Resolution-agnostic helpers ──────────────────────────────────────────
     // All text sizes derive from root height. Clamp to stay readable at any
@@ -444,9 +465,8 @@ Rectangle {
                 if (yMax > 100) { yMax = 100; yMin = 90 }
             }
 
-            // Publish to root properties (drives Y-axis labels + Behavior animations)
-            root.chartYMin = yMin
-            root.chartYMax = yMax
+            // Publish to root properties via hysteresis guard (Bug #8 fix)
+            root.updateYRange(yMin, yMax)
             var yRange = yMax - yMin
 
             // Build tick marks: 5 evenly spaced values

--- a/src/shell/native/src/aura_shell_window.cpp
+++ b/src/shell/native/src/aura_shell_window.cpp
@@ -652,7 +652,16 @@ void DragTabBar::mouseMoveEvent(QMouseEvent* event) {
             drag->setHotSpot(QPoint(20, 16));
         }
 
+        // Bug #17: QDrag::exec() runs a nested event loop that blocks the
+        // update_timer_ for the entire drag.  Stop/restart around exec() so
+        // a long drag doesn't queue stale ticks or corrupt controller state.
+        if (window_->update_timer_ != nullptr) {
+            window_->update_timer_->stop();
+        }
         drag->exec(Qt::MoveAction);
+        if (window_->update_timer_ != nullptr) {
+            window_->update_timer_->start();
+        }
         drag_tab_index_ = -1;
         return;
     }

--- a/src/shell/native/src/aura_shell_window_refresh.cpp
+++ b/src/shell/native/src/aura_shell_window_refresh.cpp
@@ -9,6 +9,12 @@
 #include <cstdlib>
 #include <string>
 
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+#include <windows.h>
+#endif
+
 namespace aura::shell {
 
 void AuraShellWindow::refresh_cockpit() {
@@ -81,11 +87,22 @@ void AuraShellWindow::refresh_cockpit() {
 
     // Refresh process list model
     if (process_model_ != nullptr && telemetry_bridge_raw_ != nullptr) {
-        // Default to 16 GB as baseline; the memory_percent bar in QML
-        // uses per-row bytes so this is only for the relative bar sizing
-        constexpr std::uint64_t kDefaultTotalMemory = 16ULL * 1024 * 1024 * 1024;
-        const std::uint64_t total_memory_estimate = kDefaultTotalMemory;
-        process_model_->refresh(telemetry_bridge_raw_, total_memory_estimate);
+        // Bug #4: use actual installed RAM instead of hardcoded 16 GB.
+        // GlobalMemoryStatusEx is ~microseconds; the == 0 guard makes it one-shot.
+        if (total_physical_memory_bytes_ == 0) {
+#ifdef _WIN32
+            MEMORYSTATUSEX mem_status{};
+            mem_status.dwLength = sizeof(mem_status);
+            if (GlobalMemoryStatusEx(&mem_status)) {
+                total_physical_memory_bytes_ = mem_status.ullTotalPhys;
+            }
+#endif
+            if (total_physical_memory_bytes_ == 0) {
+                // Safe fallback if API call fails or non-Windows build
+                total_physical_memory_bytes_ = 16ULL * 1024 * 1024 * 1024;
+            }
+        }
+        process_model_->refresh(telemetry_bridge_raw_, total_physical_memory_bytes_);
     }
 
     // Bridge theme to process QML root
@@ -148,6 +165,10 @@ void AuraShellWindow::refresh_cockpit() {
         root->setProperty("qualityHint", state.quality_hint);
         root->setProperty("timelineAnomalyAlpha", state.style_tokens.timeline_anomaly_alpha);
         root->setProperty("statusText", QString::fromStdString(state.status_line));
+        // Bug #6: let QML pause aurora/shimmer timers when panel is off-screen.
+        // quick_->isVisible() returns false when a different tab is selected in
+        // the QStackedWidget, so no extra bookkeeping is needed here.
+        root->setProperty("panelVisible", quick_->isVisible());
 
         // Per-core CPU
         QVariantList core_list;
@@ -325,9 +346,10 @@ void AuraShellWindow::refresh_cockpit() {
         }
     }
 
-    if (update_timer_ != nullptr) {
-        current_interval_seconds_ = static_cast<double>(update_timer_->interval()) / 1000.0;
-    }
+    // Bug #13: removed dead read-back of update_timer_->interval().
+    // current_interval_seconds_ is set once at construction from config and
+    // never needs to be re-read from the timer — the timer doesn't change its
+    // own interval, so this was a no-op on every tick.
 }
 
 }  // namespace aura::shell


### PR DESCRIPTION
## Summary

- **#4** Process memory bars hardcoded to 16 GB → queries `GlobalMemoryStatusEx` once on first tick
- **#5** Shimmer animation fired at 60 fps causing 60 Canvas 2D redraws/s → 30 fps Timer
- **#6** Aurora canvas timer ran when panel was hidden → `panelVisible` guard (C++ pushes `quick_->isVisible()`)
- **#8** Y-axis Behavior restarted every 1s tick causing jitter → hysteresis (`updateYRange`, 5 pp threshold) + 800ms OutExpo easing
- **#11** `cpu_alpha` and `memory_alpha` were identical → CPU gets sqrt curve (aggressive low-mid), memory gets linear high-floor (calm)
- **#12** `g_trend_state` was `thread_local` breaking cross-thread slope history → module-static
- **#13** `refresh_cockpit` ended with dead read-back of `update_timer_->interval()` every tick → removed
- **#14** C++ `interpolate_gauge_color` had flat `[0,40%]` zone; QML used continuous gradient → synced segments `[0-50]→[50-80]→[80-100]`
- **#16** `kDefaultPulseHz = 0.5` in `qt_hooks.cpp` vs `0.35` in `render_bridge.cpp` → unified to `0.35`
- **#17** `QDrag::exec()` blocked update timer for full drag duration → stop/restart `update_timer_` around exec

## Files changed
- `src/render/native/src/qt_hooks.cpp` — #11, #12, #16
- `src/render/native/src/theme.cpp` — #14
- `src/shell/native/include/aura_shell/aura_shell_window.hpp` — #4 (new member)
- `src/shell/native/src/aura_shell_window_refresh.cpp` — #4, #6, #13
- `src/shell/native/src/aura_shell_window.cpp` — #17
- `src/shell/native/qml/CockpitScene.qml` — #5, #6
- `src/shell/native/qml/TimelineScene.qml` — #8

## Build
Shell and render DLL both compile clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)