### PR TITLE
fix(shell): replace exportRequested polling with proper QML signal/slot (#15)

### DIFF
--- a/src/shell/native/CMakeLists.txt
+++ b/src/shell/native/CMakeLists.txt
@@ -56,6 +56,8 @@ if(AURA_SHELL_BUILD_APP)
             src/aura_shell_window.cpp
             src/aura_shell_window_panels.cpp
             src/aura_shell_window_refresh.cpp
+            # Header listed so AUTOMOC generates moc_aura_shell_window.cpp (Q_OBJECT).
+            include/aura_shell/aura_shell_window.hpp
         )
         target_compile_definitions(aura_shell PRIVATE
             AURA_SHELL_QML_PATH="${CMAKE_CURRENT_SOURCE_DIR}/qml/CockpitScene.qml"

--- a/src/shell/native/include/aura_shell/aura_shell_window.hpp
+++ b/src/shell/native/include/aura_shell/aura_shell_window.hpp
@@ -57,6 +57,7 @@ struct SlotWidgets {
 };
 
 class AuraShellWindow final : public QMainWindow {
+    Q_OBJECT
     friend class DragTabBar;
 public:
     explicit AuraShellWindow(const LaunchConfig& config, QWidget* parent = nullptr);
@@ -71,6 +72,10 @@ protected:
     void mouseMoveEvent(QMouseEvent* event) override;
     void mouseReleaseEvent(QMouseEvent* event) override;
     void resizeEvent(QResizeEvent* event) override;
+
+private Q_SLOTS:
+    // Bug #15: proper slot for QML exportRequested() signal, replacing polling.
+    void handle_export_requested();
 
 private:
     // --- Panel management (aura_shell_window_panels.cpp) ---

--- a/src/shell/native/qml/TimelineScene.qml
+++ b/src/shell/native/qml/TimelineScene.qml
@@ -36,10 +36,12 @@ Rectangle {
     property bool gpuAvailable: false
 
     // ── Analytics properties ──────────────────────────────────────────────
+    // Bug #15: exportRequested was a bool property polled every C++ tick.
+    // Replaced with a proper QML signal connected to AuraShellWindow::handle_export_requested().
+    signal exportRequested()
     property bool dvrStatsAvailable: false
     property var dvrStats: ({})
     property bool showStats: false
-    property bool exportRequested: false
     property string exportStatus: ""
 
     // ── Legend toggle state ───────────────────────────────────────────────
@@ -276,7 +278,7 @@ Rectangle {
             MouseArea {
                 anchors.fill: parent
                 cursorShape: Qt.PointingHandCursor
-                onClicked: root.exportRequested = true
+                onClicked: root.exportRequested()
             }
         }
     }

--- a/src/shell/native/src/aura_shell_window_panels.cpp
+++ b/src/shell/native/src/aura_shell_window_panels.cpp
@@ -5,6 +5,7 @@
 #include <QLabel>
 #include <QPushButton>
 #include <QQmlContext>
+#include <QQuickItem>
 #include <QQuickWidget>
 #include <QScrollArea>
 #include <QSizePolicy>
@@ -223,7 +224,16 @@ void AuraShellWindow::build_panel_pages() {
         // startup race where apply_theme() fires before rootObject() is available.
         connect(timeline_quick_, &QQuickWidget::statusChanged,
                 this, [this](QQuickWidget::Status status) {
-            if (status == QQuickWidget::Ready) { theme_dirty_ = true; }
+            if (status != QQuickWidget::Ready) { return; }
+            theme_dirty_ = true;
+            // Bug #15: connect QML exportRequested() signal to C++ slot now that
+            // rootObject() is available.  String-based SIGNAL/SLOT is required
+            // here because QML-defined signals have no compile-time pointer.
+            QQuickItem* tl_root = timeline_quick_->rootObject();
+            if (tl_root != nullptr) {
+                connect(static_cast<QObject*>(tl_root), SIGNAL(exportRequested()),
+                        this,                            SLOT(handle_export_requested()));
+            }
         });
 
         timeline_status_ = new QLabel("Awaiting timeline samples...", parent_page);

--- a/src/shell/native/src/aura_shell_window_refresh.cpp
+++ b/src/shell/native/src/aura_shell_window_refresh.cpp
@@ -295,36 +295,9 @@ void AuraShellWindow::refresh_cockpit() {
             tl_root->setProperty("dvrStatsAvailable", false);
         }
 
-        // Handle export request from QML
-        if (tl_root->property("exportRequested").toBool()) {
-            tl_root->setProperty("exportRequested", false);
-
-            // Build export path: ~/aura_export_<timestamp>.json
-            std::string home_dir;
-            if (const char* userprofile = std::getenv("USERPROFILE")) {
-                home_dir = userprofile;
-            } else if (const char* home = std::getenv("HOME")) {
-                home_dir = home;
-            } else {
-                home_dir = ".";
-            }
-
-            const auto now = std::chrono::system_clock::now();
-            const auto epoch = std::chrono::duration_cast<std::chrono::seconds>(
-                now.time_since_epoch()).count();
-            const std::string export_path = home_dir + "/aura_export_" +
-                std::to_string(epoch) + ".json";
-
-            std::string export_err;
-            const bool export_ok = controller_->export_dvr_json(export_path, export_err);
-            if (export_ok) {
-                tl_root->setProperty("exportStatus",
-                    QString("Exported to %1").arg(QString::fromStdString(export_path)));
-            } else {
-                tl_root->setProperty("exportStatus",
-                    QString("Export failed: %1").arg(QString::fromStdString(export_err)));
-            }
-        }
+        // Bug #15: export is now handled by handle_export_requested() slot,
+        // connected to the QML exportRequested() signal on scene load.
+        // Polling block removed.
 
         if (theme_dirty_) {
             tl_root->setProperty(
@@ -350,6 +323,46 @@ void AuraShellWindow::refresh_cockpit() {
     // current_interval_seconds_ is set once at construction from config and
     // never needs to be re-read from the timer — the timer doesn't change its
     // own interval, so this was a no-op on every tick.
+}
+
+// ---------------------------------------------------------------------------
+// Bug #15 — export slot (was polled every tick; now driven by QML signal)
+// ---------------------------------------------------------------------------
+
+void AuraShellWindow::handle_export_requested() {
+    if (!controller_) {
+        return;
+    }
+
+    // Build export path: ~/aura_export_<timestamp>.json
+    std::string home_dir;
+    if (const char* userprofile = std::getenv("USERPROFILE")) {
+        home_dir = userprofile;
+    } else if (const char* home = std::getenv("HOME")) {
+        home_dir = home;
+    } else {
+        home_dir = ".";
+    }
+
+    const auto now = std::chrono::system_clock::now();
+    const auto epoch = std::chrono::duration_cast<std::chrono::seconds>(
+        now.time_since_epoch()).count();
+    const std::string export_path = home_dir + "/aura_export_" +
+        std::to_string(epoch) + ".json";
+
+    std::string export_err;
+    const bool export_ok = controller_->export_dvr_json(export_path, export_err);
+
+    if (timeline_quick_ != nullptr && timeline_quick_->rootObject() != nullptr) {
+        QQuickItem* tl_root = timeline_quick_->rootObject();
+        if (export_ok) {
+            tl_root->setProperty("exportStatus",
+                QString("Exported to %1").arg(QString::fromStdString(export_path)));
+        } else {
+            tl_root->setProperty("exportStatus",
+                QString("Export failed: %1").arg(QString::fromStdString(export_err)));
+        }
+    }
 }
 
 }  // namespace aura::shell


### PR DESCRIPTION
## Summary

- **Bug #15** — Export button used `property bool exportRequested` polled every 1s tick in `refresh_cockpit()`. Now uses a proper QML `signal exportRequested()` → C++ `Q_SLOT handle_export_requested()`.
- Export fires immediately on button click instead of up to 1s later.

## Changes

- `CMakeLists.txt` — add `aura_shell_window.hpp` to `aura_shell` sources so AUTOMOC generates the MOC file for `Q_OBJECT`
- `aura_shell_window.hpp` — add `Q_OBJECT`, add `private Q_SLOTS: void handle_export_requested()`
- `aura_shell_window_panels.cpp` — connect QML signal → C++ slot in `statusChanged` handler; add `#include <QQuickItem>`
- `aura_shell_window_refresh.cpp` — remove 30-line polling block; implement `handle_export_requested()` slot
- `TimelineScene.qml` — `property bool exportRequested` → `signal exportRequested()`; `= true` → `()`

## Build
Reconfigured + rebuilt clean. AUTOMOC ran and generated `mocs_compilation_Release.cpp`. Both targets linked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)